### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   },
   "homepage": "https://mobxjs.github.io/mobx",
   "peerDependencies": {
-    "mobx": "^2.0.0",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "mobx": "^2.0.0"
   },
   "devDependencies": {
     "browserify": "^12.0.1",


### PR DESCRIPTION
Many libraries don't define peerDependencies any more (react-router, ..) so we can more freely use react versions of our choice.