### PR TITLE
Introducing Provider, implements #53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MobX-React Changelog
 
+### 3.4.0
+
+* Introduced context
+
 ### 3.3.1
 
 * Added typescript typings form `mobx-react/native` and `mobx-react/custom`

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ import {observer} from "mobx-react";
 * `componentWillReact` won't fire before the initial render (use `componentWillMount` instead)
 * `componentWillReact` won't fire when receiving new props or after `setState` calls (use `componentWillUpdate` instead)
 
-### `Provider`
+### `Provider` (Experimental)
+
+_This feature is marked as experimental as the exact api might change in a next minor, pending any community feedback_.
 
 `Provider` is a component that can stores (or other stuff) on React's context.
 This is useful if you have things that you don't want to pass through multiple layers of components explicitly.
@@ -139,7 +141,7 @@ class MessageList extends React.Component {
 
 Some note about passing stores around:
 * If a component ask a store and receives a store via a property with the same name, the property takes precedence. Use this to your advantage when testing!
-* Values provided through `Provider` should be final, to avoid issues like 
+* Values provided through `Provider` should be final, to avoid issues like mentioned in [React #2517](https://github.com/facebook/react/issues/2517) and [React #3973](https://github.com/facebook/react/pull/3973), where optimizations might stop the propagation of new context. Instead, make sure that if you put things in `context` that might change over time, that they are `@observable` or provide some other means to listen to changes, like callbacks.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,56 @@ import {observer} from "mobx-react";
 * `componentWillReact` won't fire before the initial render (use `componentWillMount` instead)
 * `componentWillReact` won't fire when receiving new props or after `setState` calls (use `componentWillUpdate` instead)
 
+### `Provider`
+
+`Provider` is a component that can stores (or other stuff) on React's context.
+This is useful if you have things that you don't want to pass through multiple layers of components explicitly.
+By passing a string array as first argument to `observer`, observer will pick up the named stores from the context and make them available as props of de decorated component:
+
+```javascript
+@observer(["color"])
+class Button extends React.Component {
+  render() {
+    return (
+      <button style={{background: this.props.color}}>
+        {this.props.children}
+      </button>
+    );
+  }
+}
+
+class Message extends React.Component {
+  render() {
+    return (
+      <div>
+        {this.props.text} <Button>Delete</Button>
+      </div>
+    );
+  }
+}
+
+class MessageList extends React.Component {
+  getChildContext() {
+    return {color: "purple"};
+  }
+
+  render() {
+    const children = this.props.messages.map((message) =>
+      <Message text={message.text} />
+    );
+    return <Provider color="red">
+        <div>
+            {children}
+        </div>
+    </Provider>;
+  }
+}
+```
+
+Some note about passing stores around:
+* If a component ask a store and receives a store via a property with the same name, the property takes precedence. Use this to your advantage when testing!
+* Values provided through `Provider` should be final, to avoid issues like 
+
 ## FAQ
 
 **Should I use `observer` for each component?**

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ import {observer} from "mobx-react";
 
 _This feature is marked as experimental as the exact api might change in a next minor, pending any community feedback_.
 
-`Provider` is a component that can stores (or other stuff) on React's context.
+`Provider` is a component that can pass stores (or other stuff) using React's context mechanism to child components.
 This is useful if you have things that you don't want to pass through multiple layers of components explicitly.
-By passing a string array as first argument to `observer`, observer will pick up the named stores from the context and make them available as props of de decorated component:
+By passing a string array as first argument to `observer`, observer will pick up the named stores from the context and make them available as props of the decorated component:
 
 ```javascript
 @observer(["color"])

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@
  */
 import React = require('react');
 
+// TODO: add stores / Provider
 export function observer<P>(clazz: React.StatelessComponent<P>): React.ClassicComponentClass<P>;
 export function observer<P>(renderFunction: (props: P) => React.ReactElement<any>): React.ClassicComponentClass<P>;
 export function observer<P>(clazz: React.ClassicComponentClass<P>): React.ClassicComponentClass<P>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,3 +15,7 @@ export function observer<P>(stores: string[], renderFunction: (props: P) => Reac
 export function observer<P>(stores: string[], clazz: React.ClassicComponentClass<P>): React.ClassicComponentClass<P>;
 export function observer<P>(stores: string[], clazz: React.ComponentClass<P>): React.ComponentClass<P>;
 export function observer(stores: string[]): <TFunction extends React.ComponentClass<any>>(target: TFunction) => TFunction; // decorator signature
+
+export class Provider extends React.Component<any, {}> {
+
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,15 @@
  */
 import React = require('react');
 
-// TODO: add stores / Provider
 export function observer<P>(clazz: React.StatelessComponent<P>): React.ClassicComponentClass<P>;
 export function observer<P>(renderFunction: (props: P) => React.ReactElement<any>): React.ClassicComponentClass<P>;
 export function observer<P>(clazz: React.ClassicComponentClass<P>): React.ClassicComponentClass<P>;
 export function observer<P>(clazz: React.ComponentClass<P>): React.ComponentClass<P>;
 export function observer<TFunction extends React.ComponentClass<any>>(target: TFunction): TFunction; // decorator signature
+
+// with stores
+export function observer<P>(stores: string[], clazz: React.StatelessComponent<P>): React.ClassicComponentClass<P>;
+export function observer<P>(stores: string[], renderFunction: (props: P) => React.ReactElement<any>): React.ClassicComponentClass<P>;
+export function observer<P>(stores: string[], clazz: React.ClassicComponentClass<P>): React.ClassicComponentClass<P>;
+export function observer<P>(stores: string[], clazz: React.ComponentClass<P>): React.ComponentClass<P>;
+export function observer(stores: string[]): <TFunction extends React.ComponentClass<any>>(target: TFunction) => TFunction; // decorator signature

--- a/index.js
+++ b/index.js
@@ -263,7 +263,7 @@
                 if (Object.keys(nextProps).length !== Object.keys(this.props).length)
                     console.warn("MobX Provider: The set of provided stores has changed. Please avoid changing stores as the change might not propagate to all children");
                 for (var key in nextProps)
-                    if (this.props[key] !== nextProps(key))
+                    if (this.props[key] !== nextProps[key])
                         console.warn("MobX Provider: Provided store '" + key + "' has changed. Please avoid replacing stores as the change might not propagate to all children");
             }
         });

--- a/index.js
+++ b/index.js
@@ -256,9 +256,16 @@
                 return {
                     mobxStores: stores
                 };
-            }
+            },
 
-            // TODO: warn when trying to change props?
+            componentWillReceiveProps: function(nextProps) {
+                // Maybe this warning is to aggressive?
+                if (Object.keys(nextProps).length !== Object.keys(this.props).length)
+                    console.warn("MobX Provider: The set of provided stores has changed. Please avoid changing stores as the change might not propagate to all children");
+                for (var key in nextProps)
+                    if (this.props[key] !== nextProps(key))
+                        console.warn("MobX Provider: Provided store '" + key + "' has changed. Please avoid replacing stores as the change might not propagate to all children");
+            }
         });
 
         var PropTypes = React.PropTypes;

--- a/index.js
+++ b/index.js
@@ -295,7 +295,7 @@
                     return React.createElement(component, newProps);
                 }
             });
-            Injector.contextTypes = { mobxStores: PropTypes.object.isRequired };
+            Injector.contextTypes = { mobxStores: PropTypes.object };
             return Injector;
         }
 

--- a/index.js
+++ b/index.js
@@ -62,6 +62,8 @@
         /**
          * Utilities
          */
+        var specialReactKeys = { children: true, key: true, ref: true };
+
         function patch(target, funcName) {
             var base = target[funcName];
             var mixinFunc = reactiveMixin[funcName];
@@ -189,7 +191,7 @@
                 if (!arg2) {
                     // invoked as decorator
                     return function(componentClass) {
-                        return observer(stores, componentClass);
+                        return observer(arg1, componentClass);
                     }
                 } else {
                     return createStoreInjector(arg1, observer(arg2));
@@ -251,7 +253,7 @@
                 }
                 // add own stores
                 for (var key in this.props)
-                    if (key !== "children" && key !== "key" && key != "ref")
+                    if (!specialReactKeys[key])
                         stores[key] = this.props[key];
                 return {
                     mobxStores: stores
@@ -263,7 +265,7 @@
                 if (Object.keys(nextProps).length !== Object.keys(this.props).length)
                     console.warn("MobX Provider: The set of provided stores has changed. Please avoid changing stores as the change might not propagate to all children");
                 for (var key in nextProps)
-                    if (this.props[key] !== nextProps[key])
+                    if (!specialReactKeys[key] && this.props[key] !== nextProps[key])
                         console.warn("MobX Provider: Provided store '" + key + "' has changed. Please avoid replacing stores as the change might not propagate to all children");
             }
         });
@@ -284,7 +286,7 @@
                         newProps[key] = this.props[key];
                     var baseStores = this.context.mobxStores;
                     stores.forEach(function(storeName) {
-                        if (storeName in newProps) // prefer explicit props
+                        if (storeName in newProps) // prefer props over stores
                             return;
                         if (!(storeName in baseStores))
                             throw new Error("MobX observer: Store '" + storeName + "' is not available! Make sure it is provided by some Provider");

--- a/mobx-react-custom.patch
+++ b/mobx-react-custom.patch
@@ -7,11 +7,11 @@
 -            throw new Error("mobx-react requires React to be available");
 +            throw new Error("mobx-react/custom requires React to be available");
  
-         var isDevtoolsEnabled = false;
- 
-@@ -194,10 +194,10 @@
- 
-     // UMD
+         /**
+          * dev tool support
+@@ -320,10 +320,10 @@
+      * UMD
+      */
      if (typeof exports === 'object') {
 -        module.exports = mrFactory(require('mobx'), require('react'), require('react-dom'));
 +        module.exports = mrFactory(require('mobx'), require('react'));

--- a/mobx-react-native.patch
+++ b/mobx-react-native.patch
@@ -7,11 +7,11 @@
 -            throw new Error("mobx-react requires React to be available");
 +            throw new Error("mobx-react/native requires React Native to be available");
 
-         var isDevtoolsEnabled = false;
-
-@@ -194,10 +194,10 @@
-
-     // UMD
+         /**
+          * dev tool support
+@@ -320,10 +320,10 @@
+      * UMD
+      */
      if (typeof exports === 'object') {
 -        module.exports = mrFactory(require('mobx'), require('react'), require('react-dom'));
 +        module.exports = mrFactory(require('mobx'), require('react'));

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "build": "cp index.js native.js && git apply mobx-react-native.patch && cp index.js custom.js && git apply mobx-react-custom.patch && cp index.d.ts native.d.ts && cp index.d.ts custom.d.ts",
     "prepublish": "npm run build",
-    "test": "browserify test/*.js | tape-run && tsc -p test/ts",
-    "debug": "browserify test/*.js | tape-run --browser chrome"
+    "test": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js | tape-run && tsc -p test/ts",
+    "debug": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js | tape-run --browser chrome"
   },
   "author": "Michel Weststrate",
   "license": "MIT",
@@ -25,12 +25,13 @@
   },
   "devDependencies": {
     "browserify": "^12.0.1",
+    "enzyme": "^2.3.0",
     "jquery": "^2.1.4",
     "lodash": "^4.0.1",
     "mobx": "^2.2.0",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react": "^15.1.0",
+    "react-addons-test-utils": "^15.1.0",
+    "react-dom": "^15.1.0",
     "tape": "^4.2.2",
     "tape-run": "2.1.0",
     "typescript": "^1.7.5"

--- a/test/context.js
+++ b/test/context.js
@@ -30,3 +30,104 @@ test('basic context', t => {
     t.equal(wrapper.find("div").text(), "context:bar");
     t.end();
 })
+
+test('props override context', t => {
+    var C = observer(["foo"], React.createClass({
+        render: function() {
+            return e("div", {}, "context:" + this.props.foo);
+        }
+    }));
+
+    var B = React.createClass({
+        render: function() {
+            return e(C, { foo: 42 });
+        }
+    });
+
+    var A = React.createClass({
+        render: function() {
+            return e(Provider, { foo: "bar" }, e(B, {}))
+        }
+    })
+
+    const wrapper = mount(e(A));
+    t.equal(wrapper.find("div").text(), "context:42");
+    t.end();
+})
+
+
+test('overriding stores is supported', t => {
+    var C = observer(["foo"], React.createClass({
+        render: function() {
+            return e("div", {}, "context:" + this.props.foo);
+        }
+    }));
+
+    var B = React.createClass({
+        render: function() {
+            return e(C, {});
+        }
+    });
+
+    var A = React.createClass({
+        render: function() {
+            return e(Provider, { foo: "bar" },
+                e("div", {},
+                    e("span", {},
+                        e(B, {})
+                    ),
+                    e("section", {}, 
+                        e(Provider, { foo: 42}, e(B, {}))
+                    )
+                )
+            );
+        }
+    })
+
+    const wrapper = mount(e(A));
+    t.equal(wrapper.find("span").text(), "context:bar");
+    t.equal(wrapper.find("section").text(), "context:42");
+    t.end();
+})
+
+test('store should be available', t => {
+    var C = observer(["foo"], React.createClass({
+        render: function() {
+            return e("div", {}, "context:" + this.props.foo);
+        }
+    }));
+
+    var B = React.createClass({
+        render: function() {
+            return e(C, {});
+        }
+    });
+
+    var A = React.createClass({
+        render: function() {
+            return e(Provider, { baz: 42 }, e(B, {}));
+        }
+    })
+
+    t.throws(() => mount(e(A)), /Store 'foo' is not available! Make sure it is provided by some Provider/);
+    t.end();
+})
+
+test('store is not required if prop is available', t => {
+    var C = observer(["foo"], React.createClass({
+        render: function() {
+            return e("div", {}, "context:" + this.props.foo);
+        }
+    }));
+
+    var B = React.createClass({
+        render: function() {
+            return e(C, { foo: "bar" });
+        }
+    });
+
+    const wrapper = mount(e(B));
+    t.equal(wrapper.find("div").text(), "context:bar");
+    t.end();
+})
+

--- a/test/context.js
+++ b/test/context.js
@@ -57,9 +57,9 @@ test('props override context', t => {
 
 
 test('overriding stores is supported', t => {
-    var C = observer(["foo"], React.createClass({
+    var C = observer(["foo", "bar"], React.createClass({
         render: function() {
-            return e("div", {}, "context:" + this.props.foo);
+            return e("div", {}, "context:" + this.props.foo + this.props.bar);
         }
     }));
 
@@ -71,7 +71,7 @@ test('overriding stores is supported', t => {
 
     var A = React.createClass({
         render: function() {
-            return e(Provider, { foo: "bar" },
+            return e(Provider, { foo: "bar", bar: 1337 },
                 e("div", {},
                     e("span", {},
                         e(B, {})
@@ -85,8 +85,8 @@ test('overriding stores is supported', t => {
     })
 
     const wrapper = mount(e(A));
-    t.equal(wrapper.find("span").text(), "context:bar");
-    t.equal(wrapper.find("section").text(), "context:42");
+    t.equal(wrapper.find("span").text(), "context:bar1337");
+    t.equal(wrapper.find("section").text(), "context:421337");
     t.end();
 })
 
@@ -168,7 +168,7 @@ test('warning is printed when changing stores', t => {
     t.equal(wrapper.find("span").text(), "42");
     t.equal(wrapper.find("div").text(), "context:3");
 
-    t.equal(msg, "MobX Provider: Provided store \'children\' has changed. Please avoid replacing stores as the change might not propagate to all children");
+    t.equal(msg, "MobX Provider: Provided store \'foo\' has changed. Please avoid replacing stores as the change might not propagate to all children");
 
     console.warn = baseWarn;
     t.end();

--- a/test/context.js
+++ b/test/context.js
@@ -1,0 +1,34 @@
+var React = require('react');
+var enzyme = require('enzyme');
+var mount = enzyme.mount;
+var mobx = require('mobx');
+var observer = require('../').observer;
+var Provider = require('../').Provider;
+var test = require('tape');
+var e = React.createElement;
+
+test('basic context', t => {
+    debugger;
+
+    var C = observer(["foo"], React.createClass({
+        render: function() {
+            return e("div", {}, "context:" + this.stores.foo);
+        }
+    }));
+
+    var B = React.createClass({
+        render: function() {
+            return e(C, {});
+        }
+    });
+
+    var A = React.createClass({
+        render: function() {
+            return e(Provider, { foo: "bar" }, e(B, {}))
+        }
+    })
+
+    const wrapper = mount(e(A));
+    t.equal(wrapper.find("div").text(), "context:bar");
+    t.end();
+})

--- a/test/context.js
+++ b/test/context.js
@@ -8,11 +8,9 @@ var test = require('tape');
 var e = React.createElement;
 
 test('basic context', t => {
-    debugger;
-
     var C = observer(["foo"], React.createClass({
         render: function() {
-            return e("div", {}, "context:" + this.stores.foo);
+            return e("div", {}, "context:" + this.props.foo);
         }
     }));
 

--- a/test/ts/compile-ts.tsx
+++ b/test/ts/compile-ts.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {Component} from 'react'; 
-import {observer} from '../../';
+import {observer, Provider} from '../../';
 
 @observer
 class T1 extends Component<{ pizza: number}, {}> {
@@ -76,6 +76,14 @@ const T10 = observer(["stores"], (props: { hamburger: number }) => {
 });
 
 React.createElement(observer(T8), { pizza: 4 });
+
+class ProviderTest extends Component<any, any> {
+    render() {
+        return <Provider foo={32}>
+            <div>hi</div>
+        </Provider>;
+    }
+}
 
 
 ReactDOM.render(<T10 hamburger={3} />, document.body);

--- a/test/ts/compile-ts.tsx
+++ b/test/ts/compile-ts.tsx
@@ -53,3 +53,29 @@ React.createElement(observer(T7), { pizza: 4 });
 
 
 ReactDOM.render(<T5 />, document.body);
+
+/// with stores
+@observer(["store1", "store2"])
+class T8 extends Component<{ pizza: number}, {}> {
+	render() {
+		return <div>{this.props.pizza}</div>;
+	}
+}
+
+const T9 = observer(["stores"], React.createClass({
+	getDefaultProps() {
+		return { cake: 7 };
+	},
+	render() {
+		return <div><T1 pizza = {this.props.cake} /></div>;
+	}
+}));
+
+const T10 = observer(["stores"], (props: { hamburger: number }) => {
+	return <T2 cake={this.props.hamburger} />;
+});
+
+React.createElement(observer(T8), { pizza: 4 });
+
+
+ReactDOM.render(<T10 hamburger={3} />, document.body);


### PR DESCRIPTION
MobX can now pass stores around via context! Use `Provider` to provide them, and `@observer([store names])` to make them available in your component's props

Beta build is available: `3.4.0-beta.1`
Docs: https://github.com/mobxjs/mobx-react/blob/provider/README.md#provider-experimental