### PR TITLE
Warnings on setting `propTypes`, `defaultProps` and `contextTypes` of MobxStoreInjector

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,6 +302,25 @@
             });
             Injector.contextTypes = { mobxStores: PropTypes.object };
             Injector.wrappedComponent = component;
+
+            if (process.env.NODE_ENV !== 'production') {
+                var warningOnProperties = ['propTypes', 'defaultProps', 'contextTypes'];
+
+                warningOnProperties.forEach(function(prop) {
+                    var propValue = Injector[prop];                
+                    Object.defineProperty(Injector, prop, {
+                        set: function (_) {
+                            var name = component.displayName || component.name;
+                            console.warn('Mobx Injector: you are trying to attach ' + prop +
+                                         ' to HOC instead of '+ name +'. Use `wrappedComponent` property.');
+                        },
+                        get: function() {
+                            return propValue;
+                        }
+                    });
+                });
+            }
+
             return Injector;
         }
 

--- a/test/inject.js
+++ b/test/inject.js
@@ -78,7 +78,7 @@ test('inject based context', t => {
                         e("span", {},
                             e(B, {})
                         ),
-                        e("section", {}, 
+                        e("section", {},
                             e(Provider, { foo: 42}, e(B, {}))
                         )
                     )
@@ -157,7 +157,7 @@ test('inject based context', t => {
                 return e("section", {},
                     e("span", {}, a.get()),
                     e(Provider, { foo: a.get() }, e(B, {}))
-                ); 
+                );
             }
         }))
 
@@ -175,6 +175,83 @@ test('inject based context', t => {
         console.warn = baseWarn;
         t.end();
     })
+
+    test('warning is printed when attaching propTypes/defaultProps/contextTypes to HOC not in production', t => {
+        var msg = [];
+        var baseWarn = console.warn;
+        console.warn = (m) => msg.push(m);
+
+        var C = inject(["foo"])(React.createClass({
+            displayName: 'C',
+            render: function() {
+                return e("div", {}, "context:" + this.props.foo);
+            }
+        }));
+
+        C.propTypes = {};
+        C.defaultProps = {};
+        C.contextTypes = {};
+
+        var B = React.createClass({
+            render: function() {
+                return e(C, {});
+            }
+        });
+
+        var A = React.createClass({
+            render: function() {
+                return e(Provider, { foo: "bar" }, e(B, {}))
+            }
+        })
+
+        const wrapper = mount(e(A));
+        t.equal(msg.length, 3);
+        t.equal(msg[0], "Mobx Injector: you are trying to attach propTypes to HOC instead of C. Use `wrappedComponent` property.");
+        t.equal(msg[1], "Mobx Injector: you are trying to attach defaultProps to HOC instead of C. Use `wrappedComponent` property.");
+        t.equal(msg[2], "Mobx Injector: you are trying to attach contextTypes to HOC instead of C. Use `wrappedComponent` property.");
+
+        console.warn = baseWarn;
+        t.end();
+    })
+
+
+   test('warning is not printed when attaching propTypes to HOC in production', t => {
+        var msg = [];
+        var baseWarn = console.warn;
+        console.warn = (m) => msg = m;
+
+        var env = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+
+
+        var C = inject(["foo"])(React.createClass({
+            displayName: 'C',
+            render: function() {
+                return e("div", {}, "context:" + this.props.foo);
+            }
+        }));
+
+        C.propTypes = {};
+
+        var B = React.createClass({
+            render: function() {
+                return e(C, {});
+            }
+        });
+
+        var A = React.createClass({
+            render: function() {
+                return e(Provider, { foo: "bar" }, e(B, {}))
+            }
+        })
+
+        const wrapper = mount(e(A));
+        t.equal(msg.length, 0);
+        console.warn = baseWarn;
+        process.env.NODE_ENV = env;
+        t.end();
+    })
+
 
     test('custom storesToProps', t => {
         var C = inject(


### PR DESCRIPTION
The code throws warnings when user tries to attach `propTypes`, `defaultProps` and `contextTypes` to `MobxStoreInjector` instead of wrapped component. See #70 and #84.