### PR TITLE
add a `wrappedComponent` ref on the Injector instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,6 +296,9 @@
                     for (var key in this.props)
                         newProps[key] = this.props[key];
                     newProps = grabStoresFn(this.context.mobxStores || {}, newProps, this.context);
+                    newProps.ref = function(instance) {
+                        this.wrappedComponent = instance;
+                    }
                     return React.createElement(component, newProps);
                 }
                 // TODO: should have shouldComponentUpdate?


### PR DESCRIPTION
As much as we'd like to keep things declarative in React, sometimes you have to get your hands dirty with imperative operations.

This PR allows the _instance_ of the wrapped component to be accessed, rather than just the component class:

```jsx
@inject('store')
class Child extends Component {
  ...

  doSomething() {
    ...
  }
}

/**
At this point, Child is a MobXStoreInjector wrapping the original Child,
and it has a property `wrappedComponent` which refers to the
original `Child` class itself.
*/

class Parent extends Component {
  constructor(props) {
    super(props);

    this.child = null;
  }

  onSomething = () => {
    // Currently this throws as child.wrappedComponent is undefined
    this.child.wrappedComponent.doSomething();
  }

  render() {
    const store = createStore();
    return (
      <Provider store={store}>
        <Child ref={instance => this.child = instance} />
      </Provider>
    );
  }
}
```