### PR TITLE
Pass 'secret' PropType argument to disable warning

### DIFF
--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -2,7 +2,7 @@ import { isObservableArray, isObservableObject, isObservableMap, untracked } fro
 
 // Copied from React.PropTypes
 function createChainableTypeChecker(validate) {
-  function checkType(isRequired, props, propName, componentName, location, propFullName) {
+  function checkType(isRequired, props, propName, componentName, location, propFullName, ...rest) {
     return untracked(() => {
       componentName = componentName || '<<anonymous>>';
       propFullName = propFullName || propName;
@@ -16,7 +16,7 @@ function createChainableTypeChecker(validate) {
         }
         return null;
       } else {
-        return validate(props, propName, componentName, location, propFullName);
+        return validate(props, propName, componentName, location, propFullName, ...rest);
       }
     })
   }
@@ -107,7 +107,7 @@ function createObservableTypeCheckerCreator(allowNativeType, mobxType) {
 }
 
 function createObservableArrayOfTypeChecker(allowNativeType, typeChecker) {
-  return createChainableTypeChecker(function(props, propName, componentName, location, propFullName) {
+  return createChainableTypeChecker(function(props, propName, componentName, location, propFullName, ...rest) {
     return untracked(() => {
       if (typeof typeChecker !== 'function') {
         return new Error(
@@ -124,7 +124,8 @@ function createObservableArrayOfTypeChecker(allowNativeType, typeChecker) {
           i,
           componentName,
           location,
-          propFullName + '[' + i + ']'
+          propFullName + '[' + i + ']',
+          ...rest
         );
         if (error instanceof Error) return error;
       }


### PR DESCRIPTION
As per the react docs for libraries:
https://facebook.github.io/react/warnings/dont-call-proptypes.html#fixing-the-false-positive-in-third-party-proptypes

Note that I was unable to compile / test this. I had all sorts of issues with `npm link`ing it, and it then failing on `thing instanceof ObservableArray`. In the end, I hacked this into the already-compiled source of the `npm install`d version in my repo, and verified it still worked.

Please test this thoroughly with your normal build process and react@latest.