### PR TITLE
Export propTypes as PropTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export { default as inject } from './inject';
 
 import * as propTypes from './propTypes';
 export { propTypes };
+export { propTypes as PropTypes };
 
 export default module.exports;
 


### PR DESCRIPTION
I think, that's more intuitive for react users?