### PR TITLE
Fix PropTypes import in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ MobX-react provides the following additional `PropTypes` which can be used to va
 * `arrayOrObservableArrayOf(React.PropTypes.number)`
 * `objectOrObservableObject`
 
-Use `import { PropTypes } from "react-mobx"` to import them, then use for example `PropTypes.observableArray`
+Use `import { PropTypes } from "mobx-react"` to import them, then use for example `PropTypes.observableArray`
 
 
 ### `Provider` and `inject`


### PR DESCRIPTION
The package is called mobx-react, or is this due to change?
The PropTypes should then be imported from mobx-react and not react-mobx.