### PR TITLE
Issue #155 - ES6 Test support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ index.js
 index.d.ts
 index.min.js
 .vscode
+.idea
+test/browser/test_bundle.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-script: npm run travis
+script: npm run test:travis
 after_success:
   - cat ./coverage/lcov.info|./node_modules/coveralls/bin/coveralls.js
 node_js:

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   },
   "scripts": {
     "test:ts": "tsc -p test/ts",
-    "test:travis": "webpack && browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 ] ] | tape-run && npm run test:ts",
     "test:build": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -o ./test/browser/test_bundle.js -t [ babelify --presets [ es2015 react ] ]",
-    "test:console": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 ] ] | tape-run | tap-spec && npm run test:ts",
-    "test:browser": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 ] ] | tape-run --browser chrome --render='tap-spec'",
+    "test:travis": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 react ] ] | tape-run && npm run test:ts",
+    "test:console": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 react ] ] | tape-run | tap-spec && npm run test:ts",
+    "test:open": " open ./test/browser/index.html",
+    "test:browser": "npm run test:build && npm run test:open",
     "build": "webpack && cp src/index.d.ts index.d.ts && cp src/index.d.ts native.d.ts && cp src/index.d.ts custom.d.ts",
     "prepublish": "npm run build"
   },
@@ -32,6 +33,7 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.16.0",
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "empty-module": "0.0.2",
@@ -44,7 +46,7 @@
     "react-dom": "^15.2.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2",
-    "tape-run": "2.1.0",
+    "tape-run": "^2.1.4",
     "typescript": "^1.8.10",
     "webpack": "^1.13.1"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^15.2.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2",
-    "tape-run": "^2.1.4",
+    "tape-run": "2.1.0",
     "typescript": "^1.8.10",
     "webpack": "^1.13.1"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test:ts": "tsc -p test/ts",
     "test:build": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -o ./test/browser/test_bundle.js -t [ babelify --presets [ es2015 react ] ]",
-    "test:travis": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 react ] ] | tape-run && npm run test:ts",
+    "test:travis": "webpack && browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 react ] ] | tape-run && npm run test:ts",
     "test:console": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 react ] ] | tape-run | tap-spec && npm run test:ts",
     "test:open": " open ./test/browser/index.html",
     "test:browser": "npm run test:build && npm run test:open",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "url": "https://github.com/mobxjs/mobx-react.git"
   },
   "scripts": {
+    "test:ts": "tsc -p test/ts",
+    "test:travis": "webpack && browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 ] ] | tape-run && npm run test:ts",
+    "test:build": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -o ./test/browser/test_bundle.js -t [ babelify --presets [ es2015 react ] ]",
+    "test:console": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 ] ] | tape-run | tap-spec && npm run test:ts",
+    "test:browser": "browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js -t [ babelify --presets [ es2015 ] ] | tape-run --browser chrome --render='tap-spec'",
     "build": "webpack && cp src/index.d.ts index.d.ts && cp src/index.d.ts native.d.ts && cp src/index.d.ts custom.d.ts",
-    "prepublish": "npm run build",
-    "test": "webpack && browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js | tape-run | tap-spec && tsc -p test/ts",
-    "travis": "webpack && browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js | tape-run && tsc -p test/ts",
-    "debug": "webpack && browserify -x react/addons -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/*.js | tape-run --browser chrome | tap-spec"
+    "prepublish": "npm run build"
   },
   "author": "Michel Weststrate",
   "license": "MIT",
@@ -30,6 +32,7 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-preset-es2015": "^6.9.0",
+    "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "empty-module": "0.0.2",
     "enzyme": "^2.3.0",

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Tape</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+    <script src="./test_bundle.js"></script>
+</body>
+</html>

--- a/test/context.js
+++ b/test/context.js
@@ -1,8 +1,8 @@
-import { createClass, createElement } from 'react'
+import React, { createClass } from 'react'
 import { mount } from 'enzyme'
 import test from 'tape'
 import mobx from 'mobx'
-import { observer, inject, Provider } from '../'
+import { observer, Provider } from '../'
 
 test('observer based context', t => {
   test('using observer to inject throws warning', t => {
@@ -24,16 +24,15 @@ test('observer based context', t => {
   test('basic context', t => {
     const C = observer(['foo'], createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>
       }
     }));
-    const B = createClass({
-      render:() => createElement(C, {})
-    });
-    const A = createClass({
-      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
-    });
-    const wrapper = mount(createElement(A));
+    const B = () => <C />
+    const A = () =>
+      <Provider foo='bar'>
+        <B />
+      </Provider>
+    const wrapper = mount(<A />);
     t.equal(wrapper.find('div').text(), 'context:bar');
     t.end();
   });
@@ -41,16 +40,15 @@ test('observer based context', t => {
   test('props override context', t => {
     const C = observer(['foo'], createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>
       }
     }));
-    const B = createClass({
-      render: () => createElement(C, { foo: 42 })
-    });
-    const A = createClass({
-      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
-    });
-    const wrapper = mount(createElement(A));
+    const B = () => <C foo={42} />
+    const A = () =>
+      <Provider foo='bar'>
+        <B />
+      </Provider>
+    const wrapper = mount(<A />);
     t.equal(wrapper.find('div').text(), 'context:42');
     t.end();
   });
@@ -58,25 +56,24 @@ test('observer based context', t => {
   test('overriding stores is supported', t => {
     const C = observer(['foo', 'bar'], createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo + this.props.bar);
+        return <div>context:{ this.props.foo }{ this.props.bar }</div>
       }
     }));
-    const B = createClass({
-      render: () => createElement(C, {})
-    });
-    const A = createClass({
-      render: () => createElement(Provider, { foo: 'bar', bar: 1337 },
-        createElement('div', {},
-          createElement('span', {},
-            createElement(B, {})
-          ),
-          createElement('section', {},
-            createElement(Provider, { foo: 42}, createElement(B, {}))
-          )
-        )
-      )
-    });
-    const wrapper = mount(createElement(A));
+    const B = () => <C />
+    const A = () =>
+      <Provider foo='bar' bar={1337}>
+        <div>
+          <span>
+            <B />
+          </span>
+          <section>
+            <Provider foo={42}>
+              <B />
+            </Provider>
+          </section>
+        </div>
+      </Provider>
+    const wrapper = mount(<A />);
     t.equal(wrapper.find('span').text(), 'context:bar1337');
     t.equal(wrapper.find('section').text(), 'context:421337');
     t.end();
@@ -85,29 +82,26 @@ test('observer based context', t => {
   test('store should be available', t => {
     const C = observer(['foo'], createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>
       }
     }));
-    const B = createClass({
-      render: () => createElement(C, {})
-    });
-    const A = createClass({
-      render: () => createElement(Provider, { baz: 42 }, createElement(B, {}))
-    });
-    t.throws(() => mount(createElement(A)), /Store 'foo' is not available! Make sure it is provided by some Provider/);
+    const B = () => <C />
+    const A = () =>
+      <Provider baz={ 42 }>
+        <B />
+      </Provider>
+    t.throws(() => mount(<A />), /Store 'foo' is not available! Make sure it is provided by some Provider/);
     t.end();
   });
 
   test('store is not required if prop is available', t => {
     const C = observer(['foo'], createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo)
+        return <div>context:{ this.props.foo }</div>
       }
     }));
-    const B = createClass({
-      render: () => createElement(C, { foo: 'bar' })
-    });
-    const wrapper = mount(createElement(B));
+    const B = () => <C foo='bar' />
+    const wrapper = mount(<B />);
     t.equal(wrapper.find('div').text(), 'context:bar');
     t.end();
   });
@@ -119,19 +113,22 @@ test('observer based context', t => {
     const a = mobx.observable(3);
     const C = observer(['foo'], createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>;
       }
     }));
     const B = observer(createClass({
-      render: () => createElement(C, {})
+      render: () => <C />
     }));
     const A = observer(createClass({
-      render: () => createElement('section', {},
-        createElement('span', {}, a.get()),
-        createElement(Provider, { foo: a.get() }, createElement(B, {}))
-      )
+      render: () =>
+        <section>
+          <span>{ a.get() }</span>,
+          <Provider foo={ a.get() }>
+            <B />
+          </Provider>
+        </section>
     }));
-    const wrapper = mount(createElement(A));
+    const wrapper = mount(<A />);
     t.equal(wrapper.find('span').text(), '3');
     t.equal(wrapper.find('div').text(), 'context:3');
     a.set(42);

--- a/test/context.js
+++ b/test/context.js
@@ -1,199 +1,146 @@
-var React = require('react');
-var enzyme = require('enzyme');
-var mount = enzyme.mount;
-var mobx = require('mobx');
-var observer = require('../').observer;
-var inject = require('../').inject;
-var Provider = require('../').Provider;
-var test = require('tape');
-var e = React.createElement;
+import { createClass, createElement } from 'react'
+import { mount } from 'enzyme'
+import test from 'tape'
+import mobx from 'mobx'
+import { observer, inject, Provider } from '../'
 
 test('observer based context', t => {
-    test('using observer to inject throws warning', t => {
-        // This test is here because it is the first test file being run, and mobx-react warns only once
-        const w = console.warn
-        const warns = []
-        console.warn = msg => warns.push(msg)
+  test('using observer to inject throws warning', t => {
+    const w = console.warn
+    const warns = []
+    console.warn = msg => warns.push(msg)
 
-        observer(["test"], React.createClass({
-            render: () => null
-        }))
+    observer(['test'], createClass({
+      render: () => null
+    }))
 
-        t.equal(warns.length, 1)
-        t.equal(warns[0], 'Mobx observer: Using observer to inject stores is deprecated since 4.0. Use `@inject("store1", "store2") @observer ComponentClass` or `inject("store1", "store2")(observer(componentClass))` instead of `@observer(["store1", "store2"]) ComponentClass`')
+    t.equal(warns.length, 1)
+    t.equal(warns[0], 'Mobx observer: Using observer to inject stores is deprecated since 4.0. Use `@inject("store1", "store2") @observer ComponentClass` or `inject("store1", "store2")(observer(componentClass))` instead of `@observer(["store1", "store2"]) ComponentClass`')
 
-        console.warn = w
-        t.end()
-    })
-
-    test('basic context', t => {
-        var C = observer(["foo"], React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar" }, e(B, {}))
-            }
-        })
-
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("div").text(), "context:bar");
-        t.end();
-    })
-
-    test('props override context', t => {
-        var C = observer(["foo"], React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, { foo: 42 });
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar" }, e(B, {}))
-            }
-        })
-
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("div").text(), "context:42");
-        t.end();
-    })
-
-
-    test('overriding stores is supported', t => {
-        var C = observer(["foo", "bar"], React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo + this.props.bar);
-            }
-        }));
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar", bar: 1337 },
-                    e("div", {},
-                        e("span", {},
-                            e(B, {})
-                        ),
-                        e("section", {},
-                            e(Provider, { foo: 42}, e(B, {}))
-                        )
-                    )
-                );
-            }
-        })
-
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("span").text(), "context:bar1337");
-        t.equal(wrapper.find("section").text(), "context:421337");
-        t.end();
-    })
-
-    test('store should be available', t => {
-        var C = observer(["foo"], React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { baz: 42 }, e(B, {}));
-            }
-        })
-
-        t.throws(() => mount(e(A)), /Store 'foo' is not available! Make sure it is provided by some Provider/);
-        t.end();
-    })
-
-    test('store is not required if prop is available', t => {
-        var C = observer(["foo"], React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, { foo: "bar" });
-            }
-        });
-
-        const wrapper = mount(e(B));
-        t.equal(wrapper.find("div").text(), "context:bar");
-        t.end();
-    })
-
-    test('warning is printed when changing stores', t => {
-        var msg;
-        var baseWarn = console.warn;
-        console.warn = (m) => msg = m;
-
-        var a = mobx.observable(3);
-
-        var C = observer(["foo"], React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        var B = observer(React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        }));
-
-        var A = observer(React.createClass({
-            render: function() {
-                return e("section", {},
-                    e("span", {}, a.get()),
-                    e(Provider, { foo: a.get() }, e(B, {}))
-                );
-            }
-        }))
-
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("span").text(), "3");
-        t.equal(wrapper.find("div").text(), "context:3");
-
-        a.set(42);
-
-        t.equal(wrapper.find("span").text(), "42");
-        t.equal(wrapper.find("div").text(), "context:3");
-
-        t.equal(msg, "MobX Provider: Provided store \'foo\' has changed. Please avoid replacing stores as the change might not propagate to all children");
-
-        console.warn = baseWarn;
-        t.end();
-    })
-
-
-
+    console.warn = w
     t.end()
-})
+  })
+
+  test('basic context', t => {
+    const C = observer(['foo'], createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    }));
+    const B = createClass({
+      render:() => createElement(C, {})
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
+    });
+    const wrapper = mount(createElement(A));
+    t.equal(wrapper.find('div').text(), 'context:bar');
+    t.end();
+  });
+
+  test('props override context', t => {
+    const C = observer(['foo'], createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    }));
+    const B = createClass({
+      render: () => createElement(C, { foo: 42 })
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
+    });
+    const wrapper = mount(createElement(A));
+    t.equal(wrapper.find('div').text(), 'context:42');
+    t.end();
+  });
+
+  test('overriding stores is supported', t => {
+    const C = observer(['foo', 'bar'], createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo + this.props.bar);
+      }
+    }));
+    const B = createClass({
+      render: () => createElement(C, {})
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { foo: 'bar', bar: 1337 },
+        createElement('div', {},
+          createElement('span', {},
+            createElement(B, {})
+          ),
+          createElement('section', {},
+            createElement(Provider, { foo: 42}, createElement(B, {}))
+          )
+        )
+      )
+    });
+    const wrapper = mount(createElement(A));
+    t.equal(wrapper.find('span').text(), 'context:bar1337');
+    t.equal(wrapper.find('section').text(), 'context:421337');
+    t.end();
+  });
+
+  test('store should be available', t => {
+    const C = observer(['foo'], createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    }));
+    const B = createClass({
+      render: () => createElement(C, {})
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { baz: 42 }, createElement(B, {}))
+    });
+    t.throws(() => mount(createElement(A)), /Store 'foo' is not available! Make sure it is provided by some Provider/);
+    t.end();
+  });
+
+  test('store is not required if prop is available', t => {
+    const C = observer(['foo'], createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo)
+      }
+    }));
+    const B = createClass({
+      render: () => createElement(C, { foo: 'bar' })
+    });
+    const wrapper = mount(createElement(B));
+    t.equal(wrapper.find('div').text(), 'context:bar');
+    t.end();
+  });
+
+  test('warning is printed when changing stores', t => {
+    let msg = null;
+    const baseWarn = console.warn;
+    console.warn = m => msg = m;
+    const a = mobx.observable(3);
+    const C = observer(['foo'], createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    }));
+    const B = observer(createClass({
+      render: () => createElement(C, {})
+    }));
+    const A = observer(createClass({
+      render: () => createElement('section', {},
+        createElement('span', {}, a.get()),
+        createElement(Provider, { foo: a.get() }, createElement(B, {}))
+      )
+    }));
+    const wrapper = mount(createElement(A));
+    t.equal(wrapper.find('span').text(), '3');
+    t.equal(wrapper.find('div').text(), 'context:3');
+    a.set(42);
+    t.equal(wrapper.find('span').text(), '42');
+    t.equal(wrapper.find('div').text(), 'context:3');
+    t.equal(msg, 'MobX Provider: Provided store \'foo\' has changed. Please avoid replacing stores as the change might not propagate to all children');
+    console.warn = baseWarn;
+    t.end();
+  });
+
+  t.end();
+});

--- a/test/inject.js
+++ b/test/inject.js
@@ -1,4 +1,4 @@
-import { createClass, createElement, PropTypes } from 'react'
+import React, { createClass, PropTypes } from 'react'
 import { mount } from 'enzyme'
 import test from 'tape'
 import mobx from 'mobx'
@@ -8,16 +8,15 @@ test('inject based context', t => {
   test('basic context', t => {
     const C = inject('foo')(observer(createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>
       }
     })));
-    const B = createClass({
-      render: () => createElement(C, {})
-    });
-    const A = createClass({
-      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
-    });
-    const wrapper = mount(createElement(A));
+    const B = () => <C />
+    const A = () =>
+      <Provider foo='bar'>
+        <B />
+      </Provider>
+    const wrapper = mount(<A />);
     t.equal(wrapper.find('div').text(), 'context:bar');
     t.end();
   });
@@ -25,16 +24,17 @@ test('inject based context', t => {
   test('props override context', t => {
     const C = inject('foo')(createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>
       }
     }));
-    const B = createClass({
-      render: () => createElement(C, { foo: 42 })
-    });
+    const B = () => <C foo={ 42 } />
     const A = createClass({
-      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
+      render: () =>
+        <Provider foo='bar'>
+          <B />
+        </Provider>
     });
-    const wrapper = mount(createElement(A));
+    const wrapper = mount(<A />);
     t.equal(wrapper.find('div').text(), 'context:42');
     t.end();
   });
@@ -42,25 +42,26 @@ test('inject based context', t => {
   test('overriding stores is supported', t => {
     const C = inject('foo', 'bar')(observer(createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo + this.props.bar);
+        return <div>context:{ this.props.foo }{ this.props.bar }</div>
       }
     })));
-    const B = createClass({
-      render: () => createElement(C, {})
-    });
+    const B = () => <C />
     const A = createClass({
-      render: () => createElement(Provider, { foo: 'bar', bar: 1337 },
-        createElement('div', {},
-          createElement('span', {},
-            createElement(B, {})
-          ),
-          createElement('section', {},
-            createElement(Provider, { foo: 42}, createElement(B, {}))
-          )
-        )
-      )
+      render: () =>
+        <Provider foo='bar' bar={1337}>
+          <div>
+          <span>
+            <B />
+          </span>
+            <section>
+              <Provider foo={42}>
+                <B />
+              </Provider>
+            </section>
+          </div>
+        </Provider>
     });
-    const wrapper = mount(createElement(A));
+    const wrapper = mount(<A />);
     t.equal(wrapper.find('span').text(), 'context:bar1337');
     t.equal(wrapper.find('section').text(), 'context:421337');
     t.end();
@@ -69,29 +70,28 @@ test('inject based context', t => {
   test('store should be available', t => {
     const C = inject('foo')(observer(createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>
       }
     })));
-    const B = createClass({
-      render: () => createElement(C, {})
-    });
+    const B = () => <C />
     const A = createClass({
-      render: () => createElement(Provider, { baz: 42 }, createElement(B, {}))
+      render: () =>
+        <Provider baz={42}>
+          <B />
+        </Provider>
     });
-    t.throws(() => mount(createElement(A)), /Store 'foo' is not available! Make sure it is provided by some Provider/);
+    t.throws(() => mount(<A />), /Store 'foo' is not available! Make sure it is provided by some Provider/);
     t.end();
   });
 
   test('store is not required if prop is available', t => {
     const C = inject('foo')(observer(createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>
       }
     })));
-    const B = createClass({
-      render: () => createElement(C, { foo: 'bar' })
-    });
-    const wrapper = mount(createElement(B));
+    const B = () => <C  foo='bar'/>
+    const wrapper = mount(<B />);
     t.equal(wrapper.find('div').text(), 'context:bar');
     t.end();
   });
@@ -104,10 +104,8 @@ test('inject based context', t => {
         return null;
       }
     })));
-    const B = createClass({
-      render: () => createElement(C, { a: 2, b: 2 })
-    });
-    const wrapper = mount(createElement(B));
+    const B = () => <C a={ 2 } b={ 2 } />
+    mount(<B />);
   });
 
   test('warning is printed when changing stores', t => {
@@ -117,19 +115,24 @@ test('inject based context', t => {
     const a = mobx.observable(3);
     const C = observer(['foo'], createClass({
       render() {
-        return createElement('div', {}, 'context:' + this.props.foo);
+        return <div>context:{ this.props.foo }</div>
       }
     }));
     const B = observer(createClass({
-      render: () => createElement(C, {})
+      render: () => <C />
     }));
     const A = observer(createClass({
-      render: () => createElement('section', {},
-        createElement('span', {}, a.get()),
-        createElement(Provider, { foo: a.get() }, createElement(B, {}))
-      )
+      render: () =>
+        <section>
+          <span>
+            { a.get() }
+          </span>
+          <Provider foo={ a.get() }>
+            <B />
+          </Provider>
+        </section>
     }));
-    const wrapper = mount(createElement(A));
+    const wrapper = mount(<A />);
 
     t.equal(wrapper.find('span').text(), '3');
     t.equal(wrapper.find('div').text(), 'context:3');
@@ -156,17 +159,18 @@ test('inject based context', t => {
         }
       }
     )(observer(createClass({
-      render: function() {
-        return createElement('div', {}, 'context:' + this.props.zoom + this.props.baz);
+      render() {
+        return <div>context:{ this.props.zoom }{ this.props.baz }</div>
       }
     })));
     const B = createClass({
-      render: () => createElement(C, { baz: 42 })
+      render: () => <C baz={ 42 } />
     });
-    const A = createClass({
-      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
-    })
-    const wrapper = mount(createElement(A));
+    const A = () =>
+      <Provider foo='bar'>
+        <B />
+      </Provider>
+    const wrapper = mount(<A/>);
     t.equal(wrapper.find('div').text(), 'context:bar84');
     t.end();
   });
@@ -191,7 +195,7 @@ test('inject based context', t => {
     t.ok(C.bla2 === B.bla2);
     t.deepEqual(Object.keys(C.wrappedComponent.propTypes), ['x']);
 
-    const wrapper = mount(createElement(C, { booh: 42 }));
+    const wrapper = mount(<C booh={ 42 } />);
     t.equal(wrapper.root.nodes[0].wrappedInstance.testField, 1);
     t.end();
   });
@@ -202,21 +206,20 @@ test('inject based context', t => {
     console.warn = m => msg.push(m);
     const C = inject(['foo'])(createClass({
       displayName: 'C',
-      render: function () {
-        return createElement('div', {}, 'context:' + this.props.foo);
+      render() {
+        return <div>context:{ this.props.foo }</div>;
       }
     }));
     C.propTypes = {};
     C.defaultProps = {};
     C.contextTypes = {};
 
-    const B = createClass({
-      render: () => createElement(C, {})
-    });
-    const A = createClass({
-      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
-    })
-    const wrapper = mount(createElement(A));
+    const B = () => <C />
+    const A = () =>
+      <Provider foo='bar'>
+        <B />
+      </Provider>
+    mount(<A />);
     t.equal(msg.length, 1);
     t.equal(msg[0], "Mobx Injector: you are trying to attach `contextTypes` on an component decorated with `inject` (or `observer`) HOC. Please specify the contextTypes on the wrapped component instead. It is accessible through the `wrappedComponent`");
     console.warn = baseWarn;
@@ -230,33 +233,28 @@ test('inject based context', t => {
 
     const C = inject(["foo"])(createClass({
       displayName: 'C',
-      render: function() {
+      render() {
         t.equal(this.props.y, 3);
         t.equal(this.props.x, undefined);
         return null;
       }
     }));
     C.propTypes = {
-      x: React.PropTypes.func.isRequired,
-      z: React.PropTypes.string.isRequired,
+      x: PropTypes.func.isRequired,
+      z: PropTypes.string.isRequired,
     };
     C.wrappedComponent.propTypes = {
-      a: React.PropTypes.func.isRequired,
+      a: PropTypes.func.isRequired,
     };
     C.defaultProps = {
       y: 3
     };
-
-    const B = createClass({
-      render: () => createElement(C, { z: "test" })
-    });
-    const A = createClass({
-      render: function() {
-        return createElement(Provider, { foo: "bar" }, createElement(B, {}))
-      }
-    });
-
-    const wrapper = mount(createElement(A));
+    const B = () => <C z='test' />
+    const A = () =>
+      <Provider foo='bar'>
+        <B />
+      </Provider>
+    mount(<A />);
     t.equal(msg.length, 2);
     t.equal(msg[0].split("\n")[0], 'Warning: Failed prop type: Required prop `x` was not specified in `inject-C-with-foo`.');
     t.equal(msg[1].split("\n")[0], 'Warning: Failed prop type: Required prop `a` was not specified in `C`.');
@@ -267,11 +265,11 @@ test('inject based context', t => {
   test('warning is not printed when attaching propTypes to injected component', t => {
     let msg = [];
     const baseWarn = console.warn;
-    console.warn = (m) => msg = m;
+    console.warn = m => msg = m;
 
     const C = inject(["foo"])(createClass({
       displayName: 'C',
-      render: () => createElement("div", {}, "context:" + this.props.foo)
+      render: () => <div>context:{ this.props.foo }</div>
     }));
     C.propTypes = {};
 
@@ -286,7 +284,7 @@ test('inject based context', t => {
     console.warn = m => msg = m;
     const C = inject(["foo"])(createClass({
       displayName: 'C',
-      render: () => createElement("div", {}, "context:" + this.props.foo)
+      render: () => <div>context:{ this.props.foo }</div>
     }))
     C.wrappedComponent.propTypes = {};
 
@@ -298,10 +296,13 @@ test('inject based context', t => {
   test('using a custom injector is reactive', t => {
     const user = mobx.observable({ name: 'Noa'});
     const mapper = stores => ({ name: stores.user.name });
-    const DisplayName = props => createElement('h1', {}, props.name);
+    const DisplayName = props => <h1>{ props.name }</h1>
     const User = inject(mapper)(DisplayName);
-    const App = () => createElement(Provider, { user: user }, createElement(User, {}));
-    const wrapper = mount(createElement(App));
+    const App = () =>
+      <Provider user={ user }>
+        <User />
+      </Provider>
+    const wrapper = mount(<App />);
 
     t.equal(wrapper.find('h1').text(), 'Noa');
 

--- a/test/inject.js
+++ b/test/inject.js
@@ -1,396 +1,314 @@
-var React = require('react');
-var enzyme = require('enzyme');
-var mount = enzyme.mount;
-var mobx = require('mobx');
-var observer = require('../').observer;
-var inject = require('../').inject;
-var Provider = require('../').Provider;
-var test = require('tape');
-var e = React.createElement;
+import { createClass, createElement, PropTypes } from 'react'
+import { mount } from 'enzyme'
+import test from 'tape'
+import mobx from 'mobx'
+import { observer, inject, Provider } from '../'
 
 test('inject based context', t => {
-    test('basic context', t => {
-        var C = inject("foo")(observer(React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        })));
+  test('basic context', t => {
+    const C = inject('foo')(observer(createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    })));
+    const B = createClass({
+      render: () => createElement(C, {})
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
+    });
+    const wrapper = mount(createElement(A));
+    t.equal(wrapper.find('div').text(), 'context:bar');
+    t.end();
+  });
 
-        var B = React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        });
+  test('props override context', t => {
+    const C = inject('foo')(createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    }));
+    const B = createClass({
+      render: () => createElement(C, { foo: 42 })
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
+    });
+    const wrapper = mount(createElement(A));
+    t.equal(wrapper.find('div').text(), 'context:42');
+    t.end();
+  });
 
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar" }, e(B, {}))
-            }
-        })
+  test('overriding stores is supported', t => {
+    const C = inject('foo', 'bar')(observer(createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo + this.props.bar);
+      }
+    })));
+    const B = createClass({
+      render: () => createElement(C, {})
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { foo: 'bar', bar: 1337 },
+        createElement('div', {},
+          createElement('span', {},
+            createElement(B, {})
+          ),
+          createElement('section', {},
+            createElement(Provider, { foo: 42}, createElement(B, {}))
+          )
+        )
+      )
+    });
+    const wrapper = mount(createElement(A));
+    t.equal(wrapper.find('span').text(), 'context:bar1337');
+    t.equal(wrapper.find('section').text(), 'context:421337');
+    t.end();
+  });
 
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("div").text(), "context:bar");
-        t.end();
+  test('store should be available', t => {
+    const C = inject('foo')(observer(createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    })));
+    const B = createClass({
+      render: () => createElement(C, {})
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { baz: 42 }, createElement(B, {}))
+    });
+    t.throws(() => mount(createElement(A)), /Store 'foo' is not available! Make sure it is provided by some Provider/);
+    t.end();
+  });
+
+  test('store is not required if prop is available', t => {
+    const C = inject('foo')(observer(createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    })));
+    const B = createClass({
+      render: () => createElement(C, { foo: 'bar' })
+    });
+    const wrapper = mount(createElement(B));
+    t.equal(wrapper.find('div').text(), 'context:bar');
+    t.end();
+  });
+
+  test('inject merges (and overrides) props', t => {
+    t.plan(1);
+    const C = inject(() => ({ a: 1 }))(observer(createClass({
+      render() {
+        t.deepEqual(this.props, { a: 1, b: 2 });
+        return null;
+      }
+    })));
+    const B = createClass({
+      render: () => createElement(C, { a: 2, b: 2 })
+    });
+    const wrapper = mount(createElement(B));
+  });
+
+  test('warning is printed when changing stores', t => {
+    let msg;
+    const baseWarn = console.warn;
+    console.warn = m => msg = m;
+    const a = mobx.observable(3);
+    const C = observer(['foo'], createClass({
+      render() {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    }));
+    const B = observer(createClass({
+      render: () => createElement(C, {})
+    }));
+    const A = observer(createClass({
+      render: () => createElement('section', {},
+        createElement('span', {}, a.get()),
+        createElement(Provider, { foo: a.get() }, createElement(B, {}))
+      )
+    }));
+    const wrapper = mount(createElement(A));
+
+    t.equal(wrapper.find('span').text(), '3');
+    t.equal(wrapper.find('div').text(), 'context:3');
+
+    a.set(42);
+
+    t.equal(wrapper.find('span').text(), '42');
+    t.equal(wrapper.find('div').text(), 'context:3');
+
+    t.equal(msg, 'MobX Provider: Provided store \'foo\' has changed. Please avoid replacing stores as the change might not propagate to all children');
+    console.warn = baseWarn;
+    t.end();
+  });
+
+  test('custom storesToProps', t => {
+    const C = inject(
+      (stores, props, context) => {
+        t.deepEqual(context, { mobxStores: { foo: 'bar' }});
+        t.deepEqual(stores, { foo: 'bar' });
+        t.deepEqual(props, { baz: 42 });
+        return {
+          zoom: stores.foo,
+          baz: props.baz * 2
+        }
+      }
+    )(observer(createClass({
+      render: function() {
+        return createElement('div', {}, 'context:' + this.props.zoom + this.props.baz);
+      }
+    })));
+    const B = createClass({
+      render: () => createElement(C, { baz: 42 })
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
     })
+    const wrapper = mount(createElement(A));
+    t.equal(wrapper.find('div').text(), 'context:bar84');
+    t.end();
+  });
 
-    test('props override context', t => {
-        var C = inject("foo")(React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, { foo: 42 });
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar" }, e(B, {}))
-            }
-        })
-
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("div").text(), "context:42");
-        t.end();
+  test('support static hoisting, wrappedComponent and wrappedInstance', t=> {
+    const B = createClass({
+      render() {
+        this.testField = 1;
+        return null;
+      },
+      propTypes: {
+        'x': PropTypes.object
+      }
     })
+    B.bla = 17;
+    B.bla2 = {};
+    const C = inject('booh')(B);
+    
+    t.equal(C.wrappedComponent, B);
+    t.equal(B.bla, 17);
+    t.equal(C.bla, 17);
+    t.ok(C.bla2 === B.bla2);
+    t.deepEqual(Object.keys(C.wrappedComponent.propTypes), ['x']);
 
+    const wrapper = mount(createElement(C, { booh: 42 }));
+    t.equal(wrapper.root.nodes[0].wrappedInstance.testField, 1);
+    t.end();
+  });
 
-    test('overriding stores is supported', t => {
-        var C = inject("foo", "bar")(observer(React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo + this.props.bar);
-            }
-        })));
+  test('warning is printed when attaching contextTypes to HOC', t => {
+    const msg = [];
+    const baseWarn = console.warn;
+    console.warn = m => msg.push(m);
+    const C = inject(['foo'])(createClass({
+      displayName: 'C',
+      render: function () {
+        return createElement('div', {}, 'context:' + this.props.foo);
+      }
+    }));
+    C.propTypes = {};
+    C.defaultProps = {};
+    C.contextTypes = {};
 
-        var B = React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar", bar: 1337 },
-                    e("div", {},
-                        e("span", {},
-                            e(B, {})
-                        ),
-                        e("section", {},
-                            e(Provider, { foo: 42}, e(B, {}))
-                        )
-                    )
-                );
-            }
-        })
-
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("span").text(), "context:bar1337");
-        t.equal(wrapper.find("section").text(), "context:421337");
-        t.end();
+    const B = createClass({
+      render: () => createElement(C, {})
+    });
+    const A = createClass({
+      render: () => createElement(Provider, { foo: 'bar' }, createElement(B, {}))
     })
+    const wrapper = mount(createElement(A));
+    t.equal(msg.length, 1);
+    t.equal(msg[0], "Mobx Injector: you are trying to attach `contextTypes` on an component decorated with `inject` (or `observer`) HOC. Please specify the contextTypes on the wrapped component instead. It is accessible through the `wrappedComponent`");
+    console.warn = baseWarn;
+    t.end();
+  });
 
-    test('store should be available', t => {
-        var C = inject("foo")(observer(React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        })));
+  test('propTypes and defaultProps are forwarded', t => {
+    const msg = [];
+    const baseError = console.error;
+    console.error = m => msg.push(m);
 
-        var B = React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        });
+    const C = inject(["foo"])(createClass({
+      displayName: 'C',
+      render: function() {
+        t.equal(this.props.y, 3);
+        t.equal(this.props.x, undefined);
+        return null;
+      }
+    }));
+    C.propTypes = {
+      x: React.PropTypes.func.isRequired,
+      z: React.PropTypes.string.isRequired,
+    };
+    C.wrappedComponent.propTypes = {
+      a: React.PropTypes.func.isRequired,
+    };
+    C.defaultProps = {
+      y: 3
+    };
 
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { baz: 42 }, e(B, {}));
-            }
-        })
+    const B = createClass({
+      render: () => createElement(C, { z: "test" })
+    });
+    const A = createClass({
+      render: function() {
+        return createElement(Provider, { foo: "bar" }, createElement(B, {}))
+      }
+    });
 
-        t.throws(() => mount(e(A)), /Store 'foo' is not available! Make sure it is provided by some Provider/);
-        t.end();
-    })
+    const wrapper = mount(createElement(A));
+    t.equal(msg.length, 2);
+    t.equal(msg[0].split("\n")[0], 'Warning: Failed prop type: Required prop `x` was not specified in `inject-C-with-foo`.');
+    t.equal(msg[1].split("\n")[0], 'Warning: Failed prop type: Required prop `a` was not specified in `C`.');
+    console.error = baseError;
+    t.end();
+  });
 
-    test('store is not required if prop is available', t => {
-        var C = inject("foo")(observer(React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        })));
+  test('warning is not printed when attaching propTypes to injected component', t => {
+    let msg = [];
+    const baseWarn = console.warn;
+    console.warn = (m) => msg = m;
 
-        var B = React.createClass({
-            render: function() {
-                return e(C, { foo: "bar" });
-            }
-        });
+    const C = inject(["foo"])(createClass({
+      displayName: 'C',
+      render: () => createElement("div", {}, "context:" + this.props.foo)
+    }));
+    C.propTypes = {};
 
-        const wrapper = mount(e(B));
-        t.equal(wrapper.find("div").text(), "context:bar");
-        t.end();
-    })
+    t.equal(msg.length, 0);
+    console.warn = baseWarn;
+    t.end();
+  })
 
-    test('inject merges (and overrides) props', t => {
-        t.plan(1);
-        var C = inject(function() {
-            return { a: 1 }
-        })(observer(React.createClass({
-            render: function() {
-                t.deepEqual(this.props, { a: 1, b: 2 });
-                return null;
-            }
-        })));
+  test('warning is not printed when attaching propTypes to wrappedComponent', t => {
+    let msg = [];
+    const baseWarn = console.warn;
+    console.warn = m => msg = m;
+    const C = inject(["foo"])(createClass({
+      displayName: 'C',
+      render: () => createElement("div", {}, "context:" + this.props.foo)
+    }))
+    C.wrappedComponent.propTypes = {};
 
-        var B = React.createClass({
-            render: function() {
-                return e(C, { a: 2, b: 2 });
-            }
-        });
+    t.equal(msg.length, 0);
+    console.warn = baseWarn;
+    t.end();
+  });
 
-        const wrapper = mount(e(B));
-    })
+  test('using a custom injector is reactive', t => {
+    const user = mobx.observable({ name: 'Noa'});
+    const mapper = stores => ({ name: stores.user.name });
+    const DisplayName = props => createElement('h1', {}, props.name);
+    const User = inject(mapper)(DisplayName);
+    const App = () => createElement(Provider, { user: user }, createElement(User, {}));
+    const wrapper = mount(createElement(App));
 
-    test('warning is printed when changing stores', t => {
-        var msg;
-        var baseWarn = console.warn;
-        console.warn = (m) => msg = m;
+    t.equal(wrapper.find('h1').text(), 'Noa');
 
-        var a = mobx.observable(3);
+    user.name = 'Veria';
+    t.equal(wrapper.find('h1').text(), 'Veria');
+    t.end();
+  });
 
-        var C = observer(["foo"], React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        var B = observer(React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        }));
-
-        var A = observer(React.createClass({
-            render: function() {
-                return e("section", {},
-                    e("span", {}, a.get()),
-                    e(Provider, { foo: a.get() }, e(B, {}))
-                );
-            }
-        }))
-
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("span").text(), "3");
-        t.equal(wrapper.find("div").text(), "context:3");
-
-        a.set(42);
-
-        t.equal(wrapper.find("span").text(), "42");
-        t.equal(wrapper.find("div").text(), "context:3");
-
-        t.equal(msg, "MobX Provider: Provided store \'foo\' has changed. Please avoid replacing stores as the change might not propagate to all children");
-
-        console.warn = baseWarn;
-        t.end();
-    })
-
-    test('custom storesToProps', t => {
-        var C = inject(
-            function(stores, props, context) {
-                t.deepEqual(context, { mobxStores: { foo: "bar" }});
-                t.deepEqual(stores, { foo: "bar" });
-                t.deepEqual(props, { baz: 42 });
-                return {
-                    zoom: stores.foo,
-                    baz: props.baz * 2
-                }
-            }
-        )(observer(React.createClass({
-            render: function() {
-                return e("div", {}, "context:" + this.props.zoom + this.props.baz);
-            }
-        })));
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, { baz: 42 });
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar" }, e(B, {}))
-            }
-        })
-
-        const wrapper = mount(e(A));
-        t.equal(wrapper.find("div").text(), "context:bar84");
-        t.end();
-    })
-
-    test('support static hoisting, wrappedComponent and wrappedInstance', t=> {
-        var B = React.createClass({
-            render() {
-                this.testField = 1;
-                return null;
-            },
-            propTypes: {
-                "x": React.PropTypes.object
-            }
-        })
-        B.bla = 17;
-        B.bla2 = {};
-
-        var C = inject("booh")(B);
-        t.equal(C.wrappedComponent, B);
-        t.equal(B.bla, 17);
-        t.equal(C.bla, 17);
-        t.ok(C.bla2 === B.bla2);
-        t.deepEqual(Object.keys(C.wrappedComponent.propTypes), ["x"]);
-
-        const wrapper = mount(e(C, { booh: 42 }));
-        t.equal(wrapper.root.nodes[0].wrappedInstance.testField, 1);
-
-        t.end();
-    })
-
-    test('warning is printed when attaching contextTypes to HOC', t => {
-        var msg = [];
-        var baseWarn = console.warn;
-        console.warn = (m) => msg.push(m);
-
-        var C = inject(["foo"])(React.createClass({
-            displayName: 'C',
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        C.contextTypes = {};
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, {});
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar" }, e(B, {}))
-            }
-        })
-
-        const wrapper = mount(e(A));
-        t.equal(msg.length, 1);
-        t.equal(msg[0], "Mobx Injector: you are trying to attach `contextTypes` on an component decorated with `inject` (or `observer`) HOC. Please specify the contextTypes on the wrapped component instead. It is accessible through the `wrappedComponent`");
-
-        console.warn = baseWarn;
-        t.end();
-    })
-
-
-    test('propTypes and defaultProps are forwarded', t => {
-        var msg = [];
-        var baseError = console.error;
-        console.error = (m) => msg.push(m);
-
-        var C = inject(["foo"])(React.createClass({
-            displayName: 'C',
-            render: function() {
-                t.equal(this.props.y, 3);
-                t.equal(this.props.x, undefined);
-                return null;
-            }
-        }));
-
-        C.propTypes = {
-            x: React.PropTypes.func.isRequired,
-            z: React.PropTypes.string.isRequired,
-        };
-        C.wrappedComponent.propTypes = {
-            a: React.PropTypes.func.isRequired,
-        };
-        C.defaultProps = {
-            y: 3
-        };
-
-        var B = React.createClass({
-            render: function() {
-                return e(C, { z: "test" });
-            }
-        });
-
-        var A = React.createClass({
-            render: function() {
-                return e(Provider, { foo: "bar" }, e(B, {}))
-            }
-        })
-
-        const wrapper = mount(e(A));
-        t.equal(msg.length, 2);
-        t.equal(msg[0].split("\n")[0], 'Warning: Failed prop type: Required prop `x` was not specified in `inject-C-with-foo`.');
-        t.equal(msg[1].split("\n")[0], 'Warning: Failed prop type: Required prop `a` was not specified in `C`.');
-
-        console.error = baseError;
-        t.end();
-    })
-
-
-   test('warning is not printed when attaching propTypes to injected component', t => {
-        var msg = [];
-        var baseWarn = console.warn;
-        console.warn = (m) => msg = m;
-
-        var C = inject(["foo"])(React.createClass({
-            displayName: 'C',
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        C.propTypes = {};
-
-        t.equal(msg.length, 0);
-        console.warn = baseWarn;
-        t.end();
-    })
-
-   test('warning is not printed when attaching propTypes to wrappedComponent', t => {
-        var msg = [];
-        var baseWarn = console.warn;
-        console.warn = (m) => msg = m;
-
-        var C = inject(["foo"])(React.createClass({
-            displayName: 'C',
-            render: function() {
-                return e("div", {}, "context:" + this.props.foo);
-            }
-        }));
-
-        C.wrappedComponent.propTypes = {};
-
-        t.equal(msg.length, 0);
-        console.warn = baseWarn;
-        t.end();
-    })
-
-    test('using a custom injector is reactive', t => {
-        const user = mobx.observable({ name: "Noa"})
-        const mapper = (stores) => ({ name: stores.user.name })
-
-        const DisplayName = (props) => e("h1", {}, props.name)
-        const User = inject(mapper)(DisplayName)
-        const App = () => e(Provider, { user: user }, e(User, {}))
-
-        const wrapper = mount(e(App))
-        t.equal(wrapper.find("h1").text(), "Noa")
-
-        user.name = "Veria"
-        t.equal(wrapper.find("h1").text(), "Veria")
-        t.end()
-    })
-
-    t.end()
-})
+  t.end();
+});

--- a/test/issue21.js
+++ b/test/issue21.js
@@ -1,452 +1,405 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-var observer = require('../').observer;
-var test = require('tape');
-var mobx = require('mobx');
-// var TestUtils = require('react-addons-test-utils');
-var $ = require('jquery');
-var _ = require('lodash');
+import { createClass, createElement, DOM } from 'react'
+import ReactDOM from 'react-dom'
+import test from 'tape'
+import mobx from 'mobx'
+import { observer } from '../'
+import $ from 'jquery'
+import _ from 'lodash'
 
-$("<div></div>").attr("id","testroot").appendTo($(window.document.body));
-var testRoot = document.getElementById("testroot");
+$('<div></div>').attr('id','testroot').appendTo($(window.document.body));
+const testRoot = document.getElementById('testroot');
+let topRenderCount = 0;
 
-var e = React.createElement;
-
-var wizardModel = mobx.observable({
-	steps: [
-		{
-			title: 'Size',
-			active: true
-		},
-		{
-			title: 'Fabric',
-			active: false
-		},
-		{
-			title: 'Finish',
-			active: false
-		}
-	],
-	activeStep: function () {
-		return _.find(this.steps, 'active');
-	},
-	activateNextStep: mobx.asReference(function () {
-		var nextStep = this.steps[_.findIndex(this.steps, 'active') + 1];
-		if(!nextStep) {
-			return false;
-		}
-		this.setActiveStep(nextStep);
-	}),
-	setActiveStep: function (modeToActivate) {
-		var self = this;
-		mobx.transaction(function () {
-			_.find(self.steps, 'active').active = false;
-			modeToActivate.active = true;
-		});
-	}
+const wizardModel = mobx.observable({
+  steps: [
+    {
+      title: 'Size',
+      active: true
+    },
+    {
+      title: 'Fabric',
+      active: false
+    },
+    {
+      title: 'Finish',
+      active: false
+    }
+  ],
+  activeStep() {
+    return _.find(this.steps, 'active');
+  },
+  activateNextStep: mobx.asReference(function () {
+    const nextStep = this.steps[_.findIndex(this.steps, 'active') + 1];
+    if(!nextStep) {
+      return false;
+    }
+    this.setActiveStep(nextStep);
+  }),
+  setActiveStep(modeToActivate) {
+    const self = this;
+    mobx.transaction(() => {
+      _.find(self.steps, 'active').active = false;
+      modeToActivate.active = true;
+    });
+  }
 });
 
 /** RENDERS **/
-var Wizard = observer(React.createClass({
-	displayName: 'Wizard',
-	render: function () {
-		return React.DOM.div(null,
-			React.createElement('div', null,
-				React.createElement('h1', null, 'Active Step: '),
-				React.createElement(WizardStep, {step: this.props.model.activeStep, key: 'activeMode', tester: true})
-			),
-			React.createElement('div', null,
-				React.createElement('h1', null, 'All Step: '),
-                React.createElement('p',null,'Clicking on these steps will render the active step just once.  This is what I expected.'),
-			    React.createElement(WizardSteps, {steps: this.props.model.steps, key: 'modeList'})
-			)
-		);
-	}
+
+const Wizard = observer(createClass({
+  displayName: 'Wizard',
+  render: function () {
+    return DOM.div(null,
+      createElement('div', null,
+        createElement('h1', null, 'Active Step: '),
+        createElement(WizardStep, {step: this.props.model.activeStep, key: 'activeMode', tester: true})
+      ),
+      createElement('div', null,
+        createElement('h1', null, 'All Step: '),
+        createElement('p',null,'Clicking on these steps will render the active step just once.  This is what I expected.'),
+        createElement(WizardSteps, {steps: this.props.model.steps, key: 'modeList'})
+      )
+    );
+  }
 }));
 
-var WizardSteps = observer(React.createClass({
-	displayName: 'WizardSteps',
-	componentWillMount: function () {
-		this.renderCount = 0;
-	},
-	render: function () {
-		var steps = _.map(this.props.steps, function (step) {
-			return React.DOM.div({key: step.title},
-				React.createElement(WizardStep, {step: step, key: step.title})
-			);
-		});
-		return React.DOM.div(null, steps);
-	}
+const WizardSteps = observer(createClass({
+  displayName: 'WizardSteps',
+  componentWillMount() {
+    this.renderCount = 0;
+  },
+  render() {
+    var steps = _.map(this.props.steps, step =>
+      DOM.div({key: step.title},
+        createElement(WizardStep, {step: step, key: step.title})
+      )
+    );
+    return DOM.div(null, steps);
+  }
 }));
 
-var WizardStep = observer(React.createClass({
-	displayName: 'WizardStep',
-	componentWillMount: function () {
-		this.renderCount = 0;
-	},
-	componentWillUnmount: function () {
-		console.log('Unmounting!');
-	},
-	render: function () {
-		// weird test hack:
-		if (this.props.tester === true) {
-			topRenderCount++;
-		}
-		return React.DOM.div({onClick: this.modeClickHandler},
-			'RenderCount: ' + (this.renderCount++) + ' ' + this.props.step.title + ': isActive:' + this.props.step.active);
-	},
-	modeClickHandler: function () {
-		var step = this.props.step;
-		wizardModel.setActiveStep(step);
-	}
+const WizardStep = observer(createClass({
+  displayName: 'WizardStep',
+  componentWillMount() {
+    this.renderCount = 0;
+  },
+  componentWillUnmount() {
+    console.log('Unmounting!');
+  },
+  render() {
+    // weird test hack:
+    if (this.props.tester === true) {
+      topRenderCount++;
+    }
+    return DOM.div(
+      {onClick: this.modeClickHandler},
+      'RenderCount: ' + (this.renderCount++) + ' ' + this.props.step.title + ': isActive:' + this.props.step.active
+    );
+  },
+  modeClickHandler() {
+    var step = this.props.step;
+    wizardModel.setActiveStep(step);
+  }
 }));
+
 /** END RENDERERS **/
 
-var topRenderCount = 0;
+const changeStep = stepNumber => wizardModel.setActiveStep(wizardModel.steps[stepNumber]);
 
-var changeStep = function (stepNumber) {
-	wizardModel.setActiveStep(wizardModel.steps[stepNumber]);
-
-};
-
-test('verify issue 21', function(t) {
-	ReactDOM.render(React.createElement(Wizard, {model: wizardModel}),testRoot, function() {
-		t.equal(topRenderCount, 1);
-		changeStep(0);
-
-		setTimeout(function() {
-			t.equal(topRenderCount, 2);
-			changeStep(2);
-			setTimeout(function() {
-				t.ok(topRenderCount, 3)
-				t.end();
-			}, 100);
-		}, 100);
-	});
+test('verify issue 21', t => {
+  t.plan(3)
+  ReactDOM.render(createElement(Wizard, {model: wizardModel}),testRoot, () => {
+    t.equal(topRenderCount, 1);
+    changeStep(0);
+    setTimeout(() => {
+      t.equal(topRenderCount, 2);
+      changeStep(2);
+      setTimeout(() => t.ok(topRenderCount, 3), 100);
+    }, 100);
+  });
 });
 
-test('verify prop changes are picked up', function(t) {
-    function createItem(subid, label) {
-        const res = mobx.observable({
-            id: 1,
-            label: label,
-            get text() {
-                events.push(["compute", this.subid])
-                return this.id + "." + this.subid + "." + this.label + "." + data.items.indexOf(this)
-            }
-        })
-        res.subid = subid // non reactive
-        return res
-    }
-
-    var data = mobx.observable({
-        items: [createItem(1, "hi")]
-    })
-    var events = []
-
-    var Child = observer(React.createClass({
-        componentWillReceiveProps: function (nextProps) {
-            events.push(["receive", this.props.item.subid, nextProps.item.subid])
-        },
-
-        componentWillUpdate: function (nextProps) {
-            events.push(["update", this.props.item.subid, nextProps.item.subid])
-        },
-
-        componentWillReact: function() {
-            events.push(["react", this.props.item.subid])
-        },
-
-        render: function() {
-            events.push(["render", this.props.item.subid, this.props.item.text])
-            return React.createElement("span", {}, this.props.item.text)
-        }
-    }))
-
-    var Parent = observer(React.createClass({
-        render: function() {
-            return React.createElement("div", {
-                onClick: changeStuff.bind(this), // event is needed to get batching!
-                id: "testDiv"
-            }, data.items.map(function(item) {
-                return React.createElement(Child, {
-                    key: "fixed",
-                    item: item
-                })
-            }))
-        }
-    }))
-
-    var Wrapper = React.createClass({ render: function() {
-        return React.createElement(Parent, {})
-    }})
-
-    function changeStuff() {
-        mobx.transaction(function() {
-            data.items[0].label = "hello" // schedules state change for Child
-            data.items[0] = createItem(2, "test") // Child should still receive new prop!
-        })
-        this.setState({}) // trigger update
-    }
-
-    ReactDOM.render(React.createElement(Wrapper, {}), testRoot, function() {
-        t.deepEqual(events, [
-            ["compute", 1],
-            ["render", 1, "1.1.hi.0"],
-        ])
-        events.splice(0)
-        $("#testDiv").click()
-
-        setTimeout(function() {
-            t.deepEqual(events, [
-                [ 'compute', 1 ],
-                [ 'react', 1 ],
-                [ 'receive', 1, 2 ],
-                [ 'update', 1, 2 ],
-                [ 'compute', 2 ],
-                [ 'render', 2, '1.2.test.0' ]
-            ])
-            t.end()
-        }, 100)
-    })
-})
-
-
-test('verify props is reactive', function(t) {
-    function createItem(subid, label) {
-        const res = mobx.observable({
-            id: 1,
-            label: label,
-            get text() {
-                events.push(["compute", this.subid])
-                return this.id + "." + this.subid + "." + this.label + "." + data.items.indexOf(this)
-            }
-        })
-        res.subid = subid // non reactive
-        return res
-    }
-
-    var data = mobx.observable({
-        items: [createItem(1, "hi")]
-    })
-    var events = []
-
-    var Child = observer(React.createClass({
-        componentWillMount() {
-            events.push(["mount"])
-            mobx.extendObservable(this, {
-                computedLabel: function() {
-                    events.push(["computed label", this.props.item.subid])
-                    return this.props.item.label
-                }
-            })
-        },
-
-        componentWillReceiveProps: function (nextProps) {
-            events.push(["receive", this.props.item.subid, nextProps.item.subid])
-        },
-
-        componentWillUpdate: function (nextProps) {
-            events.push(["update", this.props.item.subid, nextProps.item.subid])
-        },
-
-        componentWillReact: function() {
-            events.push(["react", this.props.item.subid])
-        },
-
-        render: function() {
-            events.push(["render", this.props.item.subid, this.props.item.text, this.computedLabel])
-            return React.createElement("span", {}, this.props.item.text + this.computedLabel)
-        }
-    }))
-
-    var Parent = observer(React.createClass({
-        render: function() {
-            return React.createElement("div", {
-                onClick: changeStuff.bind(this), // event is needed to get batching!
-                id: "testDiv"
-            }, data.items.map(function(item) {
-                return React.createElement(Child, {
-                    key: "fixed",
-                    item: item
-                })
-            }))
-        }
-    }))
-
-    var Wrapper = React.createClass({ render: function() {
-        return React.createElement(Parent, {})
-    }})
-
-    function changeStuff() {
-        mobx.transaction(function() {
-            // components start rendeirng a new item, but computed is still based on old value
-            data.items = [createItem(2, "test")]
-        })
-    }
-
-    ReactDOM.render(React.createElement(Wrapper, {}), testRoot, function() {
-        t.deepEqual(events, [
-            ["mount"],
-            ["compute", 1],
-            ["computed label", 1],
-            ["render", 1, "1.1.hi.0", "hi"],
-        ])
-        events.splice(0)
-        $("#testDiv").click()
-
-        setTimeout(function() {
-            t.deepEqual(events, [
-                [ 'compute', 1 ],
-                [ 'react', 1 ],
-                [ 'receive', 1, 2 ],
-                [ 'update', 1, 2 ],
-                [ 'compute', 2 ],
-                [ "computed label", 2],
-                [ 'render', 2, '1.2.test.0', "test" ]
-            ])
-            t.end()
-        }, 100)
-    })
-})
-
-
-test('no re-render for shallow equal props', function(t) {
-    function createItem(subid, label) {
-        const res = mobx.observable({
-            id: 1,
-            label: label,
-        })
-        res.subid = subid // non reactive
-        return res
-    }
-
-    var data = mobx.observable({
-        items: [createItem(1, "hi")],
-        parentValue: 0
-    })
-    var events = []
-
-    var Child = observer(React.createClass({
-        componentWillMount() {
-            events.push(["mount"])
-        },
-
-        componentWillReceiveProps: function (nextProps) {
-            events.push(["receive", this.props.item.subid, nextProps.item.subid])
-        },
-
-        componentWillUpdate: function (nextProps) {
-            events.push(["update", this.props.item.subid, nextProps.item.subid])
-        },
-
-        componentWillReact: function() {
-            events.push(["react", this.props.item.subid])
-        },
-
-        render: function() {
-            events.push(["render", this.props.item.subid, this.props.item.label])
-            return React.createElement("span", {}, this.props.item.label)
-        }
-    }))
-
-    var Parent = observer(React.createClass({
-        render: function() {
-            t.equal(mobx.isObservable(this.props.nonObservable), false, "object has become observable!")
-            events.push(["parent render", data.parentValue])
-            return React.createElement("div", {
-                onClick: changeStuff.bind(this), // event is needed to get batching!
-                id: "testDiv"
-            }, data.items.map(function(item) {
-                return React.createElement(Child, {
-                    key: "fixed",
-                    item: item,
-                    value: 5
-                })
-            }))
-        }
-    }))
-
-    var Wrapper = React.createClass({ render: function() {
-        return React.createElement(Parent, { nonObservable: {} })
-    }})
-
-    function changeStuff() {
-        data.items[0].label = "hi" // no change
-        data.parentValue = 1 // rerender parent
-    }
-
-    ReactDOM.render(React.createElement(Wrapper, {}), testRoot, function() {
-        t.deepEqual(events, [
-            ["parent render", 0],
-            ["mount"],
-            ["render", 1, "hi"],
-        ])
-        events.splice(0)
-        $("#testDiv").click()
-
-        setTimeout(function() {
-            t.deepEqual(events, [
-                ["parent render", 1],
-                [ 'receive', 1, 1 ],
-            ])
-            t.end()
-        }, 100)
-    })
-})
-
-test('function passed in props is not invoked on property access', function(t) {
-  var Component = observer(React.createClass({
-    render: function() {
-      return React.createElement("div", {onClick: this.props.onClick})
+test('verify prop changes are picked up', t => {
+  function createItem(subid, label) {
+    const res = mobx.observable({
+      id: 1,
+      label: label,
+      get text() {
+        events.push(['compute', this.subid]);
+        return this.id + '.' + this.subid + '.' + this.label + '.' + data.items.indexOf(this);
+      }
+    });
+    res.subid = subid; // non reactive
+    return res;
+  }
+  const data = mobx.observable({
+    items: [createItem(1, 'hi')]
+  });
+  const events = []
+  const Child = observer(createClass({
+    componentWillReceiveProps(nextProps) {
+      events.push(['receive', this.props.item.subid, nextProps.item.subid]);
+    },
+    componentWillUpdate(nextProps) {
+      events.push(['update', this.props.item.subid, nextProps.item.subid]);
+    },
+    componentWillReact() {
+      events.push(['react', this.props.item.subid]);
+    },
+    render() {
+      events.push(['render', this.props.item.subid, this.props.item.text]);
+      return createElement('span', {}, this.props.item.text);
     }
   }))
-  function onClick() {
-    t.fail(new Error("This function should not be called!"));
-  }
-  ReactDOM.render(React.createElement(Component, {onClick: onClick}), testRoot, function() {
-    t.end();
-  });
-})
 
-test('lifecycle callbacks called with correct arguments', function(t) {
+  const Parent = observer(createClass({
+    render() {
+      return createElement('div', {
+        onClick: changeStuff.bind(this), // event is needed to get batching!
+        id: 'testDiv'
+      }, data.items.map(item => createElement(Child, {
+          key: 'fixed',
+          item: item
+        })
+      ));
+    }
+  }));
+
+  const Wrapper = createClass({
+    render: () => createElement(Parent, {})
+  });
+
+  function changeStuff() {
+    mobx.transaction(() => {
+      data.items[0].label = 'hello' // schedules state change for Child
+      data.items[0] = createItem(2, 'test') // Child should still receive new prop!
+    });
+    this.setState({}); // trigger update
+  }
+
+  ReactDOM.render(createElement(Wrapper, {}), testRoot, () => {
+    t.plan(2);
+    t.deepEqual(events, [
+      ['compute', 1],
+      ['render', 1, '1.1.hi.0'],
+    ])
+    events.splice(0)
+    $('#testDiv').click()
+    setTimeout(() => t.deepEqual(events, [
+      [ 'compute', 1 ],
+      [ 'react', 1 ],
+      [ 'receive', 1, 2 ],
+      [ 'update', 1, 2 ],
+      [ 'compute', 2 ],
+      [ 'render', 2, '1.2.test.0' ]
+    ]), 100);
+  });
+});
+
+test('verify props is reactive', function(t) {
+  function createItem(subid, label) {
+    const res = mobx.observable({
+      id: 1,
+      label: label,
+      get text() {
+        events.push(['compute', this.subid])
+        return this.id + '.' + this.subid + '.' + this.label + '.' + data.items.indexOf(this)
+      }
+    })
+    res.subid = subid // non reactive
+    return res
+  }
+
+  const data = mobx.observable({
+    items: [createItem(1, 'hi')]
+  });
+  const events = [];
+
+  const Child = observer(createClass({
+    componentWillMount() {
+      events.push(['mount'])
+      mobx.extendObservable(this, {
+        computedLabel() {
+          events.push(['computed label', this.props.item.subid])
+          return this.props.item.label
+        }
+      })
+    },
+    componentWillReceiveProps(nextProps) {
+      events.push(['receive', this.props.item.subid, nextProps.item.subid])
+    },
+    componentWillUpdate(nextProps) {
+      events.push(['update', this.props.item.subid, nextProps.item.subid])
+    },
+    componentWillReact() {
+      events.push(['react', this.props.item.subid])
+    },
+    render() {
+      events.push(['render', this.props.item.subid, this.props.item.text, this.computedLabel])
+      return createElement('span', {}, this.props.item.text + this.computedLabel)
+    }
+  }));
+
+  const Parent = observer(createClass({
+    render() {
+      return createElement('div', {
+        onClick: changeStuff.bind(this), // event is needed to get batching!
+        id: 'testDiv'
+      }, data.items.map(item => createElement(Child, {
+          key: 'fixed',
+          item: item
+        })
+      ))
+    }
+  }));
+
+  const Wrapper = createClass({
+    render: () => createElement(Parent, {})
+  });
+
+  function changeStuff() {
+    mobx.transaction(() => {
+      // components start rendeirng a new item, but computed is still based on old value
+      data.items = [createItem(2, 'test')]
+    })
+  }
+
+  ReactDOM.render(createElement(Wrapper, {}), testRoot, () => {
+    t.plan(2)
+    t.deepEqual(events, [
+      ['mount'],
+      ['compute', 1],
+      ['computed label', 1],
+      ['render', 1, '1.1.hi.0', 'hi'],
+    ]);
+    events.splice(0);
+    $('#testDiv').click();
+    setTimeout(() => t.deepEqual(events, [
+      [ 'compute', 1 ],
+      [ 'react', 1 ],
+      [ 'receive', 1, 2 ],
+      [ 'update', 1, 2 ],
+      [ 'compute', 2 ],
+      [ 'computed label', 2],
+      [ 'render', 2, '1.2.test.0', 'test' ]
+    ]), 100);
+  });
+});
+
+test('no re-render for shallow equal props', function(t) {
+  function createItem(subid, label) {
+    const res = mobx.observable({
+      id: 1,
+      label: label,
+    })
+    res.subid = subid // non reactive
+    return res
+  }
+
+  const data = mobx.observable({
+    items: [createItem(1, 'hi')],
+    parentValue: 0
+  });
+  const events = [];
+
+  const Child = observer(createClass({
+    componentWillMount() {
+      events.push(['mount']);
+    },
+    componentWillReceiveProps(nextProps) {
+      events.push(['receive', this.props.item.subid, nextProps.item.subid]);
+    },
+
+    componentWillUpdate(nextProps) {
+      events.push(['update', this.props.item.subid, nextProps.item.subid]);
+    },
+    componentWillReact() {
+      events.push(['react', this.props.item.subid]);
+    },
+    render() {
+      events.push(['render', this.props.item.subid, this.props.item.label]);
+      return createElement('span', {}, this.props.item.label);
+    }
+  }));
+
+  const Parent = observer(createClass({
+    render() {
+      t.equal(mobx.isObservable(this.props.nonObservable), false, 'object has become observable!')
+      events.push(['parent render', data.parentValue])
+      return createElement('div', {
+        onClick: changeStuff.bind(this), // event is needed to get batching!
+        id: 'testDiv'
+      }, data.items.map(function(item) {
+        return createElement(Child, {
+          key: 'fixed',
+          item: item,
+          value: 5
+        })
+      }))
+    }
+  }));
+
+  const Wrapper = createClass({
+    render: () => createElement(Parent, { nonObservable: {} })
+  });
+
+  function changeStuff() {
+    data.items[0].label = 'hi'; // no change
+    data.parentValue = 1; // rerender parent
+  }
+
+  ReactDOM.render(createElement(Wrapper, {}), testRoot, () => {
+    t.plan(4);
+    t.deepEqual(events, [
+      ['parent render', 0],
+      ['mount'],
+      ['render', 1, 'hi'],
+    ]);
+    events.splice(0);
+    $('#testDiv').click();
+    setTimeout(() => t.deepEqual(events, [
+      ['parent render', 1],
+      [ 'receive', 1, 1 ],
+    ]), 100);
+  });
+});
+
+test('lifecycle callbacks called with correct arguments', t => {
   t.timeoutAfter(200);
   t.plan(6);
-  var Component = observer(React.createClass({
-    componentWillReceiveProps: function(nextProps) {
+  var Component = observer(createClass({
+    componentWillReceiveProps(nextProps) {
       t.equal(nextProps.counter, 1, 'componentWillReceiveProps: nextProps.counter === 1');
       t.equal(this.props.counter, 0, 'componentWillReceiveProps: this.props.counter === 1');
     },
-    componentWillUpdate: function(nextProps, nextState) {
+    componentWillUpdate(nextProps, nextState) {
       t.equal(nextProps.counter, 1, 'componentWillUpdate: nextProps.counter === 1');
       t.equal(this.props.counter, 0, 'componentWillUpdate: this.props.counter === 0');
     },
-    componentDidUpdate: function(prevProps, prevState) {
+    componentDidUpdate(prevProps, prevState) {
       t.equal(prevProps.counter, 0, 'componentDidUpdate: prevProps.counter === 0');
       t.equal(this.props.counter, 1, 'componentDidUpdate: this.props.counter === 1');
     },
     render: function() {
-      return React.createElement('div', {}, [
-        React.createElement('span', {key: "1"}, [this.props.counter]),
-        React.createElement('button', {key: "2", id: "testButton", onClick: this.props.onClick}),
-      ])
+      return createElement('div', {}, [
+        createElement('span', {key: '1'}, [this.props.counter]),
+        createElement('button', {key: '2', id: 'testButton', onClick: this.props.onClick}),
+      ]);
     }
-  }))
-  var Root = React.createClass({
-    getInitialState: function() {
+  }));
+  const Root = createClass({
+    getInitialState() {
       return {};
     },
-    onButtonClick: function() {
-      this.setState({counter: (this.state.counter || 0) + 1})
+    onButtonClick() {
+      this.setState({counter: (this.state.counter || 0) + 1});
     },
-    render: function() {
-      return React.createElement(Component, {
+    render() {
+      return createElement(Component, {
         counter: this.state.counter || 0,
         onClick: this.onButtonClick,
-      })
+      });
     },
-  })
-  ReactDOM.render(React.createElement(Root), testRoot, function() {
-    $("#testButton").click();
-  })
-})
+  });
+  ReactDOM.render(createElement(Root), testRoot, () => $('#testButton').click());
+});

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,137 +1,114 @@
-"use strict"
-
-var React = require('react');
-var ReactDOM = require('react-dom')
-var enzyme = require('enzyme');
-var mount = enzyme.mount;
-var mobx = require('mobx');
-var observer = require('../').observer;
-var Provider = require('../').Provider;
-var test = require('tape');
-var e = React.createElement;
+import { createClass, createElement } from 'react'
+import ReactDOM from 'react-dom'
+import { mount, shallow } from 'enzyme'
+import test from 'tape'
+import mobx from 'mobx'
+import { observer } from '../'
 
 test('custom shouldComponentUpdate is not respected for observable changes (#50)', t => {
-    var called = 0;
-    var x = mobx.observable(3)
-    var C = observer(React.createClass({
-        render: function() {
-            return e("div", {}, "value:" + x.get());
-        },
-        shouldComponentUpdate() {
-            called++;
-        }
-    }));
-
-    const wrapper = mount(e(C));
-    t.equal(wrapper.find("div").text(), "value:3");
-    t.equal(called, 0)
-    x.set(42);
-    t.equal(wrapper.find("div").text(), "value:42");
-    t.equal(called, 0)
-
-    t.end();
-})
+  let called = 0;
+  const x = mobx.observable(3);
+  const C = observer(createClass({
+    render: () => createElement('div', {}, 'value:' + x.get()),
+    shouldComponentUpdate: () => called++
+  }));
+  const wrapper = mount(createElement(C));
+  t.equal(wrapper.find('div').text(), 'value:3');
+  t.equal(called, 0)
+  x.set(42);
+  t.equal(wrapper.find('div').text(), 'value:42');
+  t.equal(called, 0);
+  t.end();
+});
 
 test('custom shouldComponentUpdate is not respected for observable changes (#50) - 2', t => {
-    // TODO: shouldComponentUpdate is meaningless with observable props...., just show warning in component definition?
-    var called = 0;
-    var y = mobx.observable(5)
-
-    var C = observer(React.createClass({
-        render: function() {
-            return e("div", {}, "value:" + this.props.y);
-        },
-        shouldComponentUpdate(nextProps) {
-            called++;
-            return nextProps.y !== 42;
-        }
-    }));
-
-    var B = observer(React.createClass({
-        render: function() {
-            return e("span", {}, e(C, {y: y.get()}));
-        }
-    }));
-
-
-    const wrapper = mount(e(B));
-    t.equal(wrapper.find("div").text(), "value:5");
-    t.equal(called, 0)
-
-    y.set(6);
-    t.equal(wrapper.find("div").text(), "value:6");
-    t.equal(called, 1)
-
-    y.set(42)
-    // t.equal(wrapper.find("div").text(), "value:6"); // not updated! TODO: fix
-    t.equal(called, 2)
-
-    y.set(7)
-    t.equal(wrapper.find("div").text(), "value:7");
-    t.equal(called, 3)
-
-    t.end();
-})
-
-test("issue mobx 405", t => {
-    function ExampleState() {
-        mobx.extendObservable(this, {
-            name: "test",
-            greetings: function() {
-                return 'Hello my name is ' + this.name;
-            }
-        })
+  // TODO: shouldComponentUpdate is meaningless with observable props...., just show warning in component definition?
+  let called = 0;
+  const y = mobx.observable(5)
+  const C = observer(createClass({
+    render() {
+      return createElement('div', {}, 'value:' + this.props.y);
+    },
+    shouldComponentUpdate(nextProps) {
+      called++;
+      return nextProps.y !== 42;
     }
+  }));
+  const B = observer(createClass({
+    render: () => createElement('span', {}, createElement(C, {y: y.get()}))
+  }));
+  const wrapper = mount(createElement(B));
+  t.equal(wrapper.find('div').text(), 'value:5');
+  t.equal(called, 0)
 
-    const ExampleView = observer(React.createClass({
-        render: function() {
-            return e("div", {},
-                e("input", {
-                    type: "text",
-                    value: this.props.exampleState.name,
-                    onChange: e => this.props.exampleState.name = e.target.value
-                }),
-                e("span", {}, this.props.exampleState.greetings)
-            );
-        }
-    }))
+  y.set(6);
+  t.equal(wrapper.find('div').text(), 'value:6');
+  t.equal(called, 1)
 
-    let exampleState = new ExampleState();
-    const wrapper = enzyme.shallow(e(ExampleView, { exampleState: exampleState}));
-    t.equal(wrapper.find('span').text(), "Hello my name is test")
+  y.set(42)
+  // t.equal(wrapper.find('div').text(), 'value:6'); // not updated! TODO: fix
+  t.equal(called, 2)
 
-    t.end()
+  y.set(7)
+  t.equal(wrapper.find('div').text(), 'value:7');
+  t.equal(called, 3)
+
+  t.end();
 })
 
-test("#85 Should handle state changing in constructors", function(t) {
-	var a = mobx.observable(2);
+test('issue mobx 405', t => {
+  function ExampleState() {
+    mobx.extendObservable(this, {
+      name: 'test',
+      greetings: function() {
+        return 'Hello my name is ' + this.name;
+      }
+    })
+  }
 
-	var child = observer(React.createClass({
-		displayName: "Child",
-		getInitialState: function() {
-			a.set(3); // one shouldn't do this!
-			return {};
-		},
-		render: function() {
-			return React.createElement("div", {}, "child:", a.get(), " - ");
-		}
-	}));
+  const ExampleView = observer(createClass({
+    render: function() {
+      return createElement('div', {},
+        createElement('input', {
+          type: 'text',
+          value: this.props.exampleState.name,
+          onChange: e => this.props.exampleState.name = e.target.value
+        }),
+        createElement('span', {}, this.props.exampleState.greetings)
+      );
+    }
+  }));
 
-	var parent = observer(function Parent() {
-		return React.createElement("span", {},
-			React.createElement(child, {}),
-            "parent:",
-			a.get()
-		);
-	});
+  const exampleState = new ExampleState();
+  const wrapper = shallow(createElement(ExampleView, { exampleState }));
+  t.equal(wrapper.find('span').text(), 'Hello my name is test');
 
-	ReactDOM.render(React.createElement(parent, {}), document.getElementById('testroot'), function() {
-		t.equal(document.getElementsByTagName("span")[0].textContent, "child:3 - parent:3")
-        a.set(5)
-		t.equal(document.getElementsByTagName("span")[0].textContent, "child:5 - parent:5")
-        a.set(7)
-		t.equal(document.getElementsByTagName("span")[0].textContent, "child:7 - parent:7")
+  t.end();
+});
 
-		t.end();
-	});
+test('#85 Should handle state changing in constructors', function(t) {
+  const a = mobx.observable(2);
+  const child = observer(createClass({
+    displayName: 'Child',
+    getInitialState() {
+      a.set(3); // one shouldn't do this!
+      return {};
+    },
+    render: () => createElement('div', {}, 'child:', a.get(), ' - ')
+  }));
+  const parent = observer(function Parent() {
+    return createElement('span', {},
+      createElement(child, {}),
+      'parent:',
+      a.get()
+    );
   });
+  ReactDOM.render(createElement(parent, {}), document.getElementById('testroot'), () => {
+    t.equal(document.getElementsByTagName('span')[0].textContent, 'child:3 - parent:3');
+    a.set(5);
+    t.equal(document.getElementsByTagName('span')[0].textContent, 'child:5 - parent:5');
+    a.set(7);
+    t.equal(document.getElementsByTagName('span')[0].textContent, 'child:7 - parent:7');
+    t.end();
+  });
+});

--- a/test/propTypes.js
+++ b/test/propTypes.js
@@ -1,13 +1,11 @@
-var test = require('tape');
-var React = require('react');
-var PropTypes = require('../').propTypes;
-var mobx = require('mobx');
-var observable = mobx.observable;
-var asMap = mobx.asMap;
+import React from 'react'
+import { PropTypes } from '../'
+import test from 'tape'
+import { observable, asMap } from 'mobx'
 
 function typeCheckFail(test, declaration, value, message) {
-  var props = {testProp: value};
-  var error = declaration(
+  const props = {testProp: value};
+  const error = declaration(
     props,
     'testProp',
     'testComponent',
@@ -19,12 +17,12 @@ function typeCheckFail(test, declaration, value, message) {
 }
 
 function typeCheckFailRequiredValues(test, declaration) {
-  var specifiedButIsNullMsg = 'The prop `testProp` is marked as required in ' +
+  const specifiedButIsNullMsg = 'The prop `testProp` is marked as required in ' +
     '`testComponent`, but its value is `null`.';
-  var unspecifiedMsg = 'The prop `testProp` is marked as required in ' +
+  const unspecifiedMsg = 'The prop `testProp` is marked as required in ' +
     '`testComponent`, but its value is \`undefined\`.';
-  var props1 = {testProp: null};
-  var error1 = declaration(
+  const props1 = {testProp: null};
+  const error1 = declaration(
     props1,
     'testProp',
     'testComponent',
@@ -33,8 +31,8 @@ function typeCheckFailRequiredValues(test, declaration) {
   );
   test.equal(error1 instanceof Error, true);
   test.equal(error1.message, specifiedButIsNullMsg);
-  var props2 = {testProp: undefined};
-  var error2 = declaration(
+  const props2 = {testProp: undefined};
+  const error2 = declaration(
     props2,
     'testProp',
     'testComponent',
@@ -43,8 +41,8 @@ function typeCheckFailRequiredValues(test, declaration) {
   );
   test.equal(error2 instanceof Error, true);
   test.equal(error2.message, unspecifiedMsg);
-  var props3 = {};
-  var error3 = declaration(
+  const props3 = {};
+  const error3 = declaration(
     props3,
     'testProp',
     'testComponent',
@@ -56,8 +54,8 @@ function typeCheckFailRequiredValues(test, declaration) {
 }
 
 function typeCheckPass(test, declaration, value) {
-  var props = {testProp: value};
-  var error = declaration(
+  const props = {testProp: value};
+  const error = declaration(
     props,
     'testProp',
     'testComponent',
@@ -67,181 +65,180 @@ function typeCheckPass(test, declaration, value) {
   test.equal(error, null);
 }
 
-
-test('Valid values', function (test) {
-  typeCheckPass(test, PropTypes.observableArray, observable([]));
-  typeCheckPass(test, PropTypes.observableArrayOf(React.PropTypes.string), observable([""]));
-  typeCheckPass(test, PropTypes.arrayOrObservableArray, observable([]));
-  typeCheckPass(test, PropTypes.arrayOrObservableArray, []);
-  typeCheckPass(test, PropTypes.arrayOrObservableArrayOf(React.PropTypes.string), observable([""]));
-  typeCheckPass(test, PropTypes.arrayOrObservableArrayOf(React.PropTypes.string), [""]);
-  typeCheckPass(test, PropTypes.observableObject, observable({}));
-  typeCheckPass(test, PropTypes.objectOrObservableObject, {});
-  typeCheckPass(test, PropTypes.objectOrObservableObject, observable({}));
-  typeCheckPass(test, PropTypes.observableMap, observable(asMap({})));
-  test.end();
+test('Valid values', t => {
+  typeCheckPass(t, PropTypes.observableArray, observable([]));
+  typeCheckPass(t, PropTypes.observableArrayOf(React.PropTypes.string), observable(['']));
+  typeCheckPass(t, PropTypes.arrayOrObservableArray, observable([]));
+  typeCheckPass(t, PropTypes.arrayOrObservableArray, []);
+  typeCheckPass(t, PropTypes.arrayOrObservableArrayOf(React.PropTypes.string), observable(['']));
+  typeCheckPass(t, PropTypes.arrayOrObservableArrayOf(React.PropTypes.string), ['']);
+  typeCheckPass(t, PropTypes.observableObject, observable({}));
+  typeCheckPass(t, PropTypes.objectOrObservableObject, {});
+  typeCheckPass(t, PropTypes.objectOrObservableObject, observable({}));
+  typeCheckPass(t, PropTypes.observableMap, observable(asMap({})));
+  t.end();
 });
 
-test('should be implicitly optional and not warn', function (test) {
-  typeCheckPass(test, PropTypes.observableArray, undefined);
-  typeCheckPass(test, PropTypes.observableArrayOf(React.PropTypes.string), undefined);
-  typeCheckPass(test, PropTypes.arrayOrObservableArray, undefined);
-  typeCheckPass(test, PropTypes.arrayOrObservableArrayOf(React.PropTypes.string), undefined);
-  typeCheckPass(test, PropTypes.observableObject, undefined);
-  typeCheckPass(test, PropTypes.objectOrObservableObject, undefined);
-  typeCheckPass(test, PropTypes.observableMap, undefined);
-  test.end()
+test('should be implicitly optional and not warn', t => {
+  typeCheckPass(t, PropTypes.observableArray, undefined);
+  typeCheckPass(t, PropTypes.observableArrayOf(React.PropTypes.string), undefined);
+  typeCheckPass(t, PropTypes.arrayOrObservableArray, undefined);
+  typeCheckPass(t, PropTypes.arrayOrObservableArrayOf(React.PropTypes.string), undefined);
+  typeCheckPass(t, PropTypes.observableObject, undefined);
+  typeCheckPass(t, PropTypes.objectOrObservableObject, undefined);
+  typeCheckPass(t, PropTypes.observableMap, undefined);
+  t.end()
 });
 
-test('should warn for missing required values, function (test)', function(test) {
-  typeCheckFailRequiredValues(test, PropTypes.observableArray.isRequired, undefined);
-  typeCheckFailRequiredValues(test, PropTypes.observableArrayOf(React.PropTypes.string).isRequired, undefined);
-  typeCheckFailRequiredValues(test, PropTypes.arrayOrObservableArray.isRequired, undefined);
-  typeCheckFailRequiredValues(test, PropTypes.arrayOrObservableArrayOf(React.PropTypes.string).isRequired, undefined);
-  typeCheckFailRequiredValues(test, PropTypes.observableObject.isRequired, undefined);
-  typeCheckFailRequiredValues(test, PropTypes.objectOrObservableObject.isRequired, undefined);
-  typeCheckFailRequiredValues(test, PropTypes.observableMap.isRequired, undefined);
-  test.end()
+test('should warn for missing required values, function (test)', t => {
+  typeCheckFailRequiredValues(t, PropTypes.observableArray.isRequired, undefined);
+  typeCheckFailRequiredValues(t, PropTypes.observableArrayOf(React.PropTypes.string).isRequired, undefined);
+  typeCheckFailRequiredValues(t, PropTypes.arrayOrObservableArray.isRequired, undefined);
+  typeCheckFailRequiredValues(t, PropTypes.arrayOrObservableArrayOf(React.PropTypes.string).isRequired, undefined);
+  typeCheckFailRequiredValues(t, PropTypes.observableObject.isRequired, undefined);
+  typeCheckFailRequiredValues(t, PropTypes.objectOrObservableObject.isRequired, undefined);
+  typeCheckFailRequiredValues(t, PropTypes.observableMap.isRequired, undefined);
+  t.end()
 });
 
-test('should fail date and regexp correctly', function (test) {
+test('should fail date and regexp correctly', t => {
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableObject,
     new Date(),
     'Invalid prop `testProp` of type `date` supplied to ' +
     '`testComponent`, expected `mobx.ObservableObject`.'
   );
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableArray,
     /please/,
     'Invalid prop `testProp` of type `regexp` supplied to ' +
     '`testComponent`, expected `mobx.ObservableArray`.'
   );
-  test.end()
+  t.end()
 });
 
-test('observableArray', function (test) {
+test('observableArray', t => {
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableArray,
     [],
     'Invalid prop `testProp` of type `array` supplied to ' +
     '`testComponent`, expected `mobx.ObservableArray`.'
   );
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableArray,
-    "",
+    '',
     'Invalid prop `testProp` of type `string` supplied to ' +
     '`testComponent`, expected `mobx.ObservableArray`.'
   );
-  test.end();
+  t.end();
 });
 
-test('arrayOrObservableArray', function (test) {
+test('arrayOrObservableArray', t => {
   typeCheckFail(
-    test,
+    t,
     PropTypes.arrayOrObservableArray,
-    "",
+    '',
     'Invalid prop `testProp` of type `string` supplied to ' +
     '`testComponent`, expected `mobx.ObservableArray` or javascript `array`.'
   );
-  test.end();
+  t.end();
 });
 
-test('observableObject', function (test) {
+test('observableObject', t => {
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableObject,
     {},
     'Invalid prop `testProp` of type `object` supplied to ' +
     '`testComponent`, expected `mobx.ObservableObject`.'
   );
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableObject,
     '',
     'Invalid prop `testProp` of type `string` supplied to ' +
     '`testComponent`, expected `mobx.ObservableObject`.'
   );
-  test.end();
+  t.end();
 });
 
-test('objectOrObservableObject', function (test) {
+test('objectOrObservableObject', t => {
   typeCheckFail(
-    test,
+    t,
     PropTypes.objectOrObservableObject,
-    "",
+    '',
     'Invalid prop `testProp` of type `string` supplied to ' +
     '`testComponent`, expected `mobx.ObservableObject` or javascript `object`.'
   );
-  test.end();
+  t.end();
 });
 
-test('observableMap', function (test) {
+test('observableMap', t => {
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableMap,
     {},
     'Invalid prop `testProp` of type `object` supplied to ' +
     '`testComponent`, expected `mobx.ObservableMap`.'
   );
-  test.end();
+  t.end();
 });
 
-test('observableArrayOf', function (test) {
+test('observableArrayOf', t => {
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableArrayOf(React.PropTypes.string),
     2,
     'Invalid prop `testProp` of type `number` supplied to ' +
     '`testComponent`, expected `mobx.ObservableArray`.'
   );
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableArrayOf(React.PropTypes.string),
     observable([2]),
     'Invalid prop `testProp[0]` of type `number` supplied to ' +
     '`testComponent`, expected `string`.'
   );
   typeCheckFail(
-    test,
+    t,
     PropTypes.observableArrayOf({ foo: PropTypes.string }),
     { foo: 'bar' },
     'Property `testProp` of component `testComponent` has invalid PropType notation.'
   );
-  test.end();
+  t.end();
 });
 
-test('arrayOrObservableArrayOf', function (test) {
+test('arrayOrObservableArrayOf', t => {
   typeCheckFail(
-    test,
+    t,
     PropTypes.arrayOrObservableArrayOf(React.PropTypes.string),
     2,
     'Invalid prop `testProp` of type `number` supplied to ' +
     '`testComponent`, expected `mobx.ObservableArray` or javascript `array`.'
   );
   typeCheckFail(
-    test,
+    t,
     PropTypes.arrayOrObservableArrayOf(React.PropTypes.string),
     observable([2]),
     'Invalid prop `testProp[0]` of type `number` supplied to ' +
     '`testComponent`, expected `string`.'
   );
   typeCheckFail(
-    test,
+    t,
     PropTypes.arrayOrObservableArrayOf(React.PropTypes.string),
     [2],
     'Invalid prop `testProp[0]` of type `number` supplied to ' +
     '`testComponent`, expected `string`.'
   );
   typeCheckFail(
-    test,
+    t,
     PropTypes.arrayOrObservableArrayOf({ foo: PropTypes.string }),
     { foo: 'bar' },
     'Property `testProp` of component `testComponent` has invalid PropType notation.'
   );
-  test.end();
+  t.end();
 });

--- a/test/stateless.js
+++ b/test/stateless.js
@@ -1,89 +1,79 @@
-var test = require('tape');
-var mobx = require('mobx');
-var React = require('react');
-var ReactDOM = require('react-dom');
-var TestUtils = require('react-addons-test-utils');
-var observer = require('../').observer;
-var propTypes = require('../').propTypes;
-
-var $ = require('jquery');
-
-var e = React.createElement;
+import { createClass, PropTypes, createElement } from 'react'
+import ReactDOM from 'react-dom'
+import test from 'tape'
+import mobx from 'mobx'
+import { observer, propTypes } from '../'
+import $ from 'jquery'
 
 
-var stateLessComp = function (props) {
-	return e("div", {}, "result: " + props.testProp);
+const stateLessComp = function (props) {
+  return createElement('div', {}, 'result: ' + props.testProp);
 }
 stateLessComp.propTypes = {
-	testProp: React.PropTypes.string
+  testProp: PropTypes.string
 }
 stateLessComp.defaultProps = {
-	testProp: 'default value for prop testProp'
+  testProp: 'default value for prop testProp'
 }
 
-test('stateless component with propTypes', function (test) {
-	var statelessCompObserver = observer(stateLessComp);
-	test.equal(statelessCompObserver.getDefaultProps().testProp, 'default value for prop testProp', "default property value should be propagated");
-	var originalConsoleError = console.error
-	var beenWarned = false
-	console.error = function () {
-		beenWarned = true;
-	}
-	React.createElement(statelessCompObserver, { testProp: 10 })
-	console.error = originalConsoleError;
-	test.equal(beenWarned, true, "an error should be logged with a property type warning")
+test('stateless component with propTypes', t => {
+  const statelessCompObserver = observer(stateLessComp);
+  t.equal(statelessCompObserver.getDefaultProps().testProp, 'default value for prop testProp', 'default property value should be propagated');
+  const originalConsoleError = console.error
+  let beenWarned = false
+  console.error =  () => beenWarned = true;
+  createElement(statelessCompObserver, { testProp: 10 })
+  console.error = originalConsoleError;
+  t.equal(beenWarned, true, 'an error should be logged with a property type warning')
 
-	ReactDOM.render(e(statelessCompObserver, { testProp: "hello world" }), document.getElementById('testroot'), function () {
-		test.equal($("#testroot").text(), "result: hello world");
-		test.end();
-	});
+  ReactDOM.render(
+    createElement(statelessCompObserver, { testProp: 'hello world' }),
+    document.getElementById('testroot'),
+    function () {
+      t.equal($('#testroot').text(), 'result: hello world');
+      t.end();
+    }
+    );
 });
 
-test('stateless component with context support', function (test) {
-	var stateLessCompWithContext = function (props, context) { return e("div", {}, "context: " + context.testContext); }
-	stateLessCompWithContext.contextTypes = { testContext: React.PropTypes.string }
-	var stateLessCompWithContextObserver = observer(stateLessCompWithContext);
-
-	var ContextProvider =  React.createClass({
-		childContextTypes: stateLessCompWithContext.contextTypes,
-		getChildContext:   function() { return { testContext: 'hello world' }; },
-		render:            function() { return e(stateLessCompWithContextObserver); }
-	});
-
-	ReactDOM.render(e(ContextProvider), document.getElementById('testroot'), function () {
-		test.equal($("#testroot").text(), "context: hello world");
-		test.end();
-	});
-});
-
-test('component with observable propTypes', function (t) {
-    var component = React.createClass({
-        render: function() {
-            return null;
-        },
-        propTypes: {
-            a1: propTypes.observableArray,
-            a2: propTypes.arrayOrObservableArray
-        }
-    })
-	var originalConsoleError = console.error
-	var warnings = [];
-	console.error = function (msg) {
-		warnings.push(msg);
-	};
-	React.createElement(component, {
-        a1: [],
-        a2: []
-    })
-	t.equal(warnings.length, 1)
-
-	React.createElement(component, {
-        a1: mobx.observable([]),
-        a2: mobx.observable([])
-    })
-	t.equal(warnings.length, 1)
-
-	console.error = originalConsoleError;
-
+test('stateless component with context support', t => {
+  const stateLessCompWithContext = (props, context) => createElement('div', {}, 'context: ' + context.testContext);
+  stateLessCompWithContext.contextTypes = { testContext: PropTypes.string };
+  const stateLessCompWithContextObserver = observer(stateLessCompWithContext);
+  var ContextProvider =  createClass({
+    childContextTypes: stateLessCompWithContext.contextTypes,
+    getChildContext: () => ({ testContext: 'hello world' }),
+    render: () => createElement(stateLessCompWithContextObserver)
+  })
+  ReactDOM.render(createElement(ContextProvider), document.getElementById('testroot'), () => {
+    t.equal($('#testroot').text(), 'context: hello world');
     t.end();
+  });
+});
+
+test('component with observable propTypes', t => {
+  const component = createClass({
+    render: () => null,
+    propTypes: {
+      a1: propTypes.observableArray,
+      a2: propTypes.arrayOrObservableArray
+    }
+  })
+  var originalConsoleError = console.error
+  var warnings = [];
+  console.error = msg => warnings.push(msg)
+  createElement(component, {
+    a1: [],
+    a2: []
+  })
+  t.equal(warnings.length, 1)
+
+  createElement(component, {
+    a1: mobx.observable([]),
+    a2: mobx.observable([])
+  })
+  t.equal(warnings.length, 1)
+
+  console.error = originalConsoleError;
+  t.end();
 });

--- a/test/stateless.js
+++ b/test/stateless.js
@@ -1,4 +1,4 @@
-import { createClass, PropTypes, createElement } from 'react'
+import React, { createClass, PropTypes, createElement } from 'react'
 import ReactDOM from 'react-dom'
 import test from 'tape'
 import mobx from 'mobx'
@@ -6,9 +6,8 @@ import { observer, propTypes } from '../'
 import $ from 'jquery'
 
 
-const stateLessComp = function (props) {
-  return createElement('div', {}, 'result: ' + props.testProp);
-}
+const stateLessComp = ({testProp}) => <div>result: { testProp }</div>
+
 stateLessComp.propTypes = {
   testProp: PropTypes.string
 }
@@ -17,17 +16,17 @@ stateLessComp.defaultProps = {
 }
 
 test('stateless component with propTypes', t => {
-  const statelessCompObserver = observer(stateLessComp);
-  t.equal(statelessCompObserver.getDefaultProps().testProp, 'default value for prop testProp', 'default property value should be propagated');
+  const StatelessCompObserver = observer(stateLessComp);
+  t.equal(StatelessCompObserver.getDefaultProps().testProp, 'default value for prop testProp', 'default property value should be propagated');
   const originalConsoleError = console.error
   let beenWarned = false
   console.error =  () => beenWarned = true;
-  createElement(statelessCompObserver, { testProp: 10 })
+  const wrapper = <StatelessCompObserver testProp={ 10 } />
   console.error = originalConsoleError;
   t.equal(beenWarned, true, 'an error should be logged with a property type warning')
 
   ReactDOM.render(
-    createElement(statelessCompObserver, { testProp: 'hello world' }),
+    <StatelessCompObserver testProp='hello world' />,
     document.getElementById('testroot'),
     function () {
       t.equal($('#testroot').text(), 'result: hello world');
@@ -37,43 +36,35 @@ test('stateless component with propTypes', t => {
 });
 
 test('stateless component with context support', t => {
-  const stateLessCompWithContext = (props, context) => createElement('div', {}, 'context: ' + context.testContext);
-  stateLessCompWithContext.contextTypes = { testContext: PropTypes.string };
-  const stateLessCompWithContextObserver = observer(stateLessCompWithContext);
-  var ContextProvider =  createClass({
-    childContextTypes: stateLessCompWithContext.contextTypes,
+  const StateLessCompWithContext = (props, context) => createElement('div', {}, 'context: ' + context.testContext);
+  StateLessCompWithContext.contextTypes = { testContext: PropTypes.string };
+  const StateLessCompWithContextObserver = observer(StateLessCompWithContext);
+  const ContextProvider =  createClass({
+    childContextTypes: StateLessCompWithContext.contextTypes,
     getChildContext: () => ({ testContext: 'hello world' }),
-    render: () => createElement(stateLessCompWithContextObserver)
+    render: () => <StateLessCompWithContextObserver />
   })
-  ReactDOM.render(createElement(ContextProvider), document.getElementById('testroot'), () => {
+  ReactDOM.render(<ContextProvider />, document.getElementById('testroot'), () => {
     t.equal($('#testroot').text(), 'context: hello world');
     t.end();
   });
 });
 
 test('component with observable propTypes', t => {
-  const component = createClass({
+  const Component = createClass({
     render: () => null,
     propTypes: {
       a1: propTypes.observableArray,
       a2: propTypes.arrayOrObservableArray
     }
   })
-  var originalConsoleError = console.error
-  var warnings = [];
+  const originalConsoleError = console.error
+  const warnings = [];
   console.error = msg => warnings.push(msg)
-  createElement(component, {
-    a1: [],
-    a2: []
-  })
+  const firstWrapper = <Component a1={ [] } a2={ [] } />
   t.equal(warnings.length, 1)
-
-  createElement(component, {
-    a1: mobx.observable([]),
-    a2: mobx.observable([])
-  })
+  const secondWrapper = <Component a1={  mobx.observable([]) } a2={  mobx.observable([]) } />
   t.equal(warnings.length, 1)
-
   console.error = originalConsoleError;
   t.end();
 });

--- a/test/transactions.js
+++ b/test/transactions.js
@@ -1,4 +1,4 @@
-import { createClass, createElement } from 'react'
+import React, { createClass } from 'react'
 import ReactDOM from 'react-dom'
 import test from 'tape'
 import mobx from 'mobx'
@@ -21,12 +21,10 @@ test('mobx issue 50', t => {
 	}
 	let asText = '';
 	let willReactCount = 0;
-	mobx.autorun(function() {
-		asText = [foo.a.get(), foo.b.get(), foo.c.get()].join(':');
-	});
+	mobx.autorun(() => asText = [foo.a.get(), foo.b.get(), foo.c.get()].join(':'));
 	const Test = mobxReact.observer(createClass({
 		componentWillReact: () => willReactCount++,
-		render: () => createElement('div', { id: 'x' }, [foo.a.get(), foo.b.get(), foo.c.get()].join(','))
+		render: () => <div id='x'>{ [foo.a.get(), foo.b.get(), foo.c.get()].join(',') }</div>
 	}));
 	// In 3 seconds, flip a and b. This will change c.
 	setTimeout(flipStuff, 200);
@@ -38,7 +36,7 @@ test('mobx issue 50', t => {
 		t.end();
 	}, 400);
 
-	ReactDOM.render(createElement(Test), document.getElementById('testroot'));
+	ReactDOM.render(<Test />, document.getElementById('testroot'));
 });
 
 test('React.render should respect transaction', t => {
@@ -46,15 +44,15 @@ test('React.render should respect transaction', t => {
 	const loaded = mobx.observable(false);
 	const valuesSeen = [];
 
-	const component = mobxReact.observer(() => {
+	const Component = mobxReact.observer(() => {
 		valuesSeen.push(a.get());
 		if (loaded.get())
-			return createElement('div', {}, a.get());
+			return <div>{ a.get() }</div>
 		else
-			return createElement('div', {}, 'loading');
+			return <div>loading</div>
 	});
 
-	ReactDOM.render(createElement(component, {}), document.getElementById('testroot'));
+	ReactDOM.render(<Component />, document.getElementById('testroot'));
 	mobx.transaction(() => {
 		a.set(3);
 		a.set(4);
@@ -72,17 +70,17 @@ test('React.render in transaction should succeed', t => {
 	const a = mobx.observable(2);
 	const loaded = mobx.observable(false);
 	const valuesSeen = [];
-	const component = mobxReact.observer(() => {
+	const Component = mobxReact.observer(() => {
 		valuesSeen.push(a.get());
 		if (loaded.get())
-			return createElement('div', {}, a.get());
+			return <div>{ a.get() }</div>
 		else
-			return createElement('div', {}, 'loading');
+			return <div>loading</div>
 	});
 
 	mobx.transaction(() => {
 		a.set(3);
-		ReactDOM.render(createElement(component, {}), document.getElementById('testroot'));
+		ReactDOM.render(<Component />, document.getElementById('testroot'));
 		a.set(4);
 		loaded.set(true);
 	});

--- a/test/transactions.js
+++ b/test/transactions.js
@@ -1,104 +1,95 @@
-var mobx = require("mobx");
-var tape = require("tape");
-var mobxReact = require("../");
-var ReactDOM = require("react-dom");
-var React = require("react");
+import { createClass, createElement } from 'react'
+import ReactDOM from 'react-dom'
+import test from 'tape'
+import mobx from 'mobx'
+import mobxReact from '../'
 
-tape.test("mobx issue 50", function(test) {
-	
-	var foo = {
+test('mobx issue 50', t => {
+	const foo = {
 		a: mobx.observable(true),
 		b: mobx.observable(false),
-		c: mobx.observable(function() { 
-			console.log("evaluate c");
-			return foo.b.get(); 
+		c: mobx.observable(function() {
+			console.log('evaluate c');
+			return foo.b.get();
 		})
 	};
-	
 	function flipStuff() {
-		mobx.transaction(function() {
+		mobx.transaction(() => {
 			foo.a.set(!foo.a.get());
 			foo.b.set(!foo.b.get());
-		});
+		})
 	}
-	
-	var asText = "";
-    var willReactCount = 0;
+	let asText = '';
+	let willReactCount = 0;
 	mobx.autorun(function() {
-		asText = [foo.a.get(), foo.b.get(), foo.c.get()].join(":");
+		asText = [foo.a.get(), foo.b.get(), foo.c.get()].join(':');
 	});
-		
-	var Test = mobxReact.observer(React.createClass({
-        componentWillReact: function() {
-            willReactCount++;
-        },
-		render: function() {
-			return (React.createElement("div", { id: 'x' }, [foo.a.get(), foo.b.get(), foo.c.get()].join(",")));
-		}
+	const Test = mobxReact.observer(createClass({
+		componentWillReact: () => willReactCount++,
+		render: () => createElement('div', { id: 'x' }, [foo.a.get(), foo.b.get(), foo.c.get()].join(','))
 	}));
-	
 	// In 3 seconds, flip a and b. This will change c.
 	setTimeout(flipStuff, 200);
 
-	setTimeout(function() {
-		test.equal(asText, "false:true:true");
-		test.equal(document.getElementById('x').innerHTML, "false,true,true");
-        test.equal(willReactCount, 1);
-		test.end();
+	setTimeout(() => {
+		t.equal(asText, 'false:true:true');
+		t.equal(document.getElementById('x').innerHTML, 'false,true,true');
+		t.equal(willReactCount, 1);
+		t.end();
 	}, 400);
-	
-	ReactDOM.render(React.createElement(Test), document.getElementById('testroot'));
+
+	ReactDOM.render(createElement(Test), document.getElementById('testroot'));
 });
 
-tape.test("React.render should respect transaction", function(t) {
-	var a = mobx.observable(2);
-	var loaded = mobx.observable(false);
-	var valuesSeen = [];
+test('React.render should respect transaction', t => {
+	const a = mobx.observable(2);
+	const loaded = mobx.observable(false);
+	const valuesSeen = [];
 
-	var component = mobxReact.observer(function() {
+	const component = mobxReact.observer(() => {
 		valuesSeen.push(a.get());
 		if (loaded.get())
-			return React.createElement("div", {}, a.get());
+			return createElement('div', {}, a.get());
 		else
-			return React.createElement("div", {}, "loading");
+			return createElement('div', {}, 'loading');
 	});
-	
-	ReactDOM.render(React.createElement(component, {}), document.getElementById('testroot'));
-	mobx.transaction(function() {
+
+	ReactDOM.render(createElement(component, {}), document.getElementById('testroot'));
+	mobx.transaction(() => {
 		a.set(3);
 		a.set(4);
 		loaded.set(true);
 	});
 
-	setTimeout(function() {
-		t.equal(document.body.textContent.replace(/\s+/g,""), "4");
+	setTimeout(() => {
+		t.equal(document.body.textContent.replace(/\s+/g,''), '4');
 		t.deepEqual(valuesSeen, [2, 4]);
 		t.end();
-	}, 400);	
+	}, 400);
 });
 
-tape.test("React.render in transaction should succeed", function(t) {
-	var a = mobx.observable(2);
-	var loaded = mobx.observable(false);
-	var valuesSeen = [];
-	var component = mobxReact.observer(function() {
+test('React.render in transaction should succeed', t => {
+	const a = mobx.observable(2);
+	const loaded = mobx.observable(false);
+	const valuesSeen = [];
+	const component = mobxReact.observer(() => {
 		valuesSeen.push(a.get());
 		if (loaded.get())
-			return React.createElement("div", {}, a.get());
+			return createElement('div', {}, a.get());
 		else
-			return React.createElement("div", {}, "loading");
+			return createElement('div', {}, 'loading');
 	});
-	
-	mobx.transaction(function() {
+
+	mobx.transaction(() => {
 		a.set(3);
-		ReactDOM.render(React.createElement(component, {}), document.getElementById('testroot'));
+		ReactDOM.render(createElement(component, {}), document.getElementById('testroot'));
 		a.set(4);
 		loaded.set(true);
 	});
 
-	setTimeout(function() {
-		t.equal(document.body.textContent.replace(/\s+/g,""), "4");
+	setTimeout(() => {
+		t.equal(document.body.textContent.replace(/\s+/g,''), '4');
 		t.deepEqual(valuesSeen, [3, 4]);
 		t.end();
-	}, 400);	
+	}, 400);
 });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,33 +1,33 @@
-var test = require('tape');
-var mobx = require('mobx');
-var observer = require('../').observer;
+import test from 'tape'
+import mobx from 'mobx'
+import { observer } from '../'
 
 // TODO:
-test.skip('testIsComponentReactive', function(test) {
-    var component = observer({ render: function() {}});
-    test.equal(component.isMobXReactObserver, true);
-    test.equal(mobx.isObservable(component), false); // dependencies not known yet
-    test.equal(mobx.isObservable(component.render), false); // dependencies not known yet
+test.skip('testIsComponentReactive', t => {
+    const component = observer({ render: () => null });
+    t.equal(component.isMobXReactObserver, true);
+    t.equal(mobx.isObservable(component), false); // dependencies not known yet
+    t.equal(mobx.isObservable(component.render), false); // dependencies not known yet
 
     component.componentWillMount();
     component.render();
-    test.equal(mobx.isObservable(component.render), true); // dependencies not known yet
-    test.equal(mobx.isObservable(component), false);
+    t.equal(mobx.isObservable(component.render), true); // dependencies not known yet
+    t.equal(mobx.isObservable(component), false);
 
     mobx.extendObservable(component, {});
-    test.equal(mobx.isObservable(component), true);
+    t.equal(mobx.isObservable(component), true);
 
-    test.end();
+    t.end();
 });
 
 // TODO:
-test.skip('testGetDNode', function(test) {
+test.skip('testGetDNode', t => {
     var getD = mobx.extras.getDNode;
 
-    var c = observer({ render: function() {}});
+    const c = observer({ render: function() {}});
     c.componentWillMount();
     c.render();
-    test.ok(c.$mobx);
+    t.ok(c.$mobx);
 
-    test.end();
+    t.end();
 });


### PR DESCRIPTION
Solve issue [#155](https://github.com/mobxjs/mobx-react/issues/155):

Add support of `es6` and `react` to tests and refactor them. 
Also add ability to build tests bundle and run it in browser: `npm run test:build`

@mweststrate please review

The next step to rewrite `jquery` to `enzyme` from some tests file.