### PR TITLE
Fix order of (recently added) type definitions from most to least specific

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,10 +17,10 @@ export function observer<P>(stores: string[], clazz: React.ComponentClass<P>): R
 export function observer<P>(stores: string[]): <TFunction extends React.ComponentClass<P>>(target: TFunction) => TFunction; // decorator signature
 
 // inject
-export function inject<P>(...stores: string[]): <TFunction extends React.ComponentClass<P>>(target: TFunction) => TFunction; // decorator signature
-export function inject<T, P>(storesToProps : (stores: any, nextProps: P, context:any) => T): <TFunction extends React.ComponentClass<T | P>>(target: TFunction) => TFunction; // decorator
 export function inject<P>(...stores: string[]): <TFunction extends React.StatelessComponent<P>>(target: TFunction) => TFunction; // decorator signature
+export function inject<P>(...stores: string[]): <TFunction extends React.ComponentClass<P>>(target: TFunction) => TFunction; // decorator signature
 export function inject<T, P>(storesToProps : (stores: any, nextProps: P, context:any) => T): <TFunction extends React.StatelessComponent<T | P>>(target: TFunction) => TFunction; // decorator
+export function inject<T, P>(storesToProps : (stores: any, nextProps: P, context:any) => T): <TFunction extends React.ComponentClass<T | P>>(target: TFunction) => TFunction; // decorator
 
 export class Provider extends React.Component<any, {}> {
 


### PR DESCRIPTION
Just found out that the order of the type definitions I added (v4.0.1) is not right. Something to do with specificity as far as I can see. Didn't work as intended before. Does work with this PR.

(I hadn't found out earlier because I had tested them as a merged declaration, in which new definitions are _prepended_ the existing ones I suppose.)

Sorry!