### PR TITLE
Quick Grammar fix to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you don't want to mark a component as observer, for example to reduce the dep
 
 ### Enabling decorators (optional)
 
-Decorators are currently a stage-2 ESNext feature. How to enable them is document [here](https://github.com/mobxjs/mobx#enabling-decorators-optional).
+Decorators are currently a stage-2 ESNext feature. How to enable them is documented [here](https://github.com/mobxjs/mobx#enabling-decorators-optional).
 
 ### Should I still use smart and dumb components?
 


### PR DESCRIPTION
.  Just a quick fix. Now "decorators are **documented** here", rather than "decorators are **document** here.