### PR TITLE
Allow Component<void, void>

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2",
     "tape-run": "2.1.0",
-    "typescript": "^1.8.10",
+    "typescript": "^2.1.4",
     "webpack": "^1.13.1"
   },
   "dependencies": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,7 +8,7 @@ export type IReactComponent<P> = React.StatelessComponent<P> | React.ComponentCl
 
 export function observer<P>(clazz: IReactComponent<P>): React.ClassicComponentClass<P>;
 export function observer<P>(clazz: React.ClassicComponentClass<P>): React.ClassicComponentClass<P>;
-export function observer<P, TFunction extends React.ComponentClass<P>>(target: TFunction): TFunction; // decorator signature
+export function observer<P, TFunction extends React.ComponentClass<P | void>>(target: TFunction): TFunction; // decorator signature
 
 export function inject<P>(...stores: string[]): <TFunction extends IReactComponent<P>>(target: TFunction) => TFunction; // decorator signature
 export function inject<T, P>(storesToProps : IStoresToProps<T, P>): <TFunction extends IReactComponent<T | P>>(target: TFunction) => TFunction; // decorator

--- a/test/ts/compile-ts.tsx
+++ b/test/ts/compile-ts.tsx
@@ -102,7 +102,7 @@ class T15 extends Component<{ pizza: number, x?: number }, {}> {
 }
 const T16 = inject(() => ({ x: 3 }))(T15);
 
-class T17 extends React.Component<{}, {}> {
+class T17 extends Component<{}, {}> {
     render() {
         return <div>
             <T11 pizza={3} x={1} />

--- a/test/ts/compile-ts.tsx
+++ b/test/ts/compile-ts.tsx
@@ -23,10 +23,10 @@ const T2 = observer(React.createClass({
 }));
 
 const T3 = observer((props: { hamburger: number }) => {
-	return <T2 cake={this.props.hamburger} />;
+	return <T2 cake={props.hamburger} />;
 });
 
-const T4 = ({sandwich}: { sandwich: number }) => <div><T3 hamburger={this.props.sandwich} /></div>;
+const T4 = ({sandwich}: { sandwich: number }) => <div><T3 hamburger={sandwich} /></div>;
 
 const T5 = observer(() => {
 	return <T3 hamburger={17} />;
@@ -75,7 +75,7 @@ const T9 = observer(["stores"], React.createClass({
 }));
 
 const T10 = observer(["stores"], (props: { hamburger: number }) => {
-	return <T2 cake={this.props.hamburger} />;
+	return <T2 cake={props.hamburger} />;
 });
 
 React.createElement(observer(T8), { pizza: 4 });

--- a/test/ts/compile-ts.tsx
+++ b/test/ts/compile-ts.tsx
@@ -151,3 +151,13 @@ class ObserverTest extends Component<any, any> {
 		return <Observer>{() => <div>test</div>}</Observer>;
 	}
 }
+
+@observer
+class ComponentWithoutPropsAndState extends Component<void, void> {
+    componentDidUpdate() {
+    }
+
+    render() {
+        return (<div>Hello!</div>)
+    }
+}

--- a/test/ts/tsconfig.json
+++ b/test/ts/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"target": "es5",
 		"noImplicitAny": true,
+		"noImplicitThis": false,
+		"strictNullChecks": true,
 		"experimentalDecorators": true,
 		"jsx": "react",
 		"noEmit": true,
@@ -10,6 +12,6 @@
 		"module": "commonjs"
 	},
 	"exclude": [
-		
+
 	]
 }


### PR DESCRIPTION
Fix https://github.com/mobxjs/mobx/issues/665 and #97

Now you can write:
```TypeScript
@observer
class ComponentWithoutPropsAndState extends Component<void, void> {
    componentDidUpdate() {
    }

    render() {
        return (<div>Hello!</div>)
    }
}
```

The solution was a simple `| void` inside index.d.ts