### PR TITLE
remove shouldComponentUpdate check

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -224,19 +224,12 @@ const reactiveMixin = {
     }
   },
 
-  shouldComponentUpdate: function(nextProps, nextState) {
+  shouldComponentUpdate: function() {
     if (isUsingStaticRendering) {
       console.warn("[mobx-react] It seems that a re-rendering of a React component is triggered while in static (server-side) mode. Please make sure components are rendered only once server-side.");
     }
-    // update on any state changes (as is the default)
-    if (this.state !== nextState) {
-      return true;
-    }
-    // update if props are shallowly not equal, inspired by PureRenderMixin
-    // we could return just 'false' here, and avoid the `skipRender` checks etc
-    // however, it is nicer if lifecycle events are triggered like usually,
-    // so we return true here if props are shallowly modified.
-    return isObjectShallowModified(this.props, nextProps);
+
+    return true;
   }
 };
 


### PR DESCRIPTION
I was using `react-router@4.0.0-beta.7` with `mobx-react/observer`.

`react-router@4` uses `Router#setState` to trigger re-render from history changes, which means every component that specifies `shouldComponentUpdate` must be responsible for location changes.

One solution is to use `@withRouter` along with `@observer`, which might be really redundant.

Given the fact that current code of `shouldComponentUpdate` defined in `observer` is behaving like `PureRenderMixin`, I suggest removing it since if users really need it they would have defined it or used `PureRenderMixin`/`React.PureComponent`, it shouldn't harm much restoring to default behavior.

Looking forward to your response. Thank you for your dedication!