### PR TITLE
Improve component class naming

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -297,6 +297,7 @@ export function observer(arg1, arg2) {
   const target = componentClass.prototype || componentClass;
   mixinLifecycleEvents(target)
   componentClass.isMobXReactObserver = true;
+  componentClass.displayName = 'Observer(' + (componentClass.displayName || componentClass.name || '<unknown>') + ')';
   return componentClass;
 }
 


### PR DESCRIPTION
Changes component `displayName` from `MyComponent` to `Observer(MyComponent)`.