### PR TITLE
Add react-native field to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Or CDN: https://unpkg.com/mobx-react (namespace: `mobxReact`)
 
 ```javascript
 import {observer} from 'mobx-react';
-// - or -
-import {observer} from 'mobx-react/native';
 // - or, for custom renderers without DOM: -
 import {observer} from 'mobx-react/custom';
 ```

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.1.3",
   "description": "React bindings for MobX. Create fully reactive components.",
   "main": "index.js",
+  "react-native": "native.js",
   "typings": "index",
   "repository": {
     "type": "git",


### PR DESCRIPTION
With this change you can import from `native.js` by
```js
import {observe} from 'mobx-react'
``` 
React Native packager will automatically use correct file.