### PR TITLE
fix rollup umd runtime error re: module is not defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,9 @@ export { propTypes as PropTypes };
 import { errorsReporter } from './observer';
 export const onError = fn => errorsReporter.on(fn);
 
-export default module.exports;
+export default exports;
 
 /* DevTool support */
 if (typeof __MOBX_DEVTOOLS_GLOBAL_HOOK__ === 'object') {
-  __MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobxReact(module.exports, mobx)
+  __MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobxReact(exports, mobx)
 }


### PR DESCRIPTION
* ES2015 doesn't define `module`, nor `module.exports`
* Rollup's UMD wrapper doesn't pass in `module`, but it does pass in `exports`
* Since a bare variable name in JS is valid, and assumed to reference a variable in ambient/global scope, we can just use `exports` instead of `module.exports`

