### PR TITLE
Drop using module.exports for devtools

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,8 @@ export const onError = fn => errorsReporter.on(fn);
 export default exports;
 
 /* DevTool support */
+import { renderReporter, componentByNodeRegistery, trackComponents } from './observer';
 if (typeof __MOBX_DEVTOOLS_GLOBAL_HOOK__ === 'object') {
-  __MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobxReact(exports, mobx)
+  const mobxReact = { renderReporter, componentByNodeRegistery, trackComponents };
+  __MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobxReact(mobxReact, mobx)
 }


### PR DESCRIPTION
Seems that using `exports` / `module.exports` has become tuff nowadays (https://github.com/mobxjs/mobx-react/pull/265, https://github.com/mobxjs/mobx/issues/1039) 