### PR TITLE
Fix isStateless check for native arrow func

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,3 +1,5 @@
 export function isStateless(component) {
-  return !component.prototype.render;
+  // `function() {}` has prototype, but `() => {}` doesn't
+  // `() => {}` via Babel has prototype too.
+  return !(component.prototype && component.prototype.render);
 }


### PR DESCRIPTION
ref #277 

- `function() {}` has prototype
- `() => {}`(native) doesn't

And I found Babel(transform-es2015-arrow-functions) transpiles `() => {}` into `function() {}`.