### PR TITLE
Fixed findDOMNode if-condition when used with non-DOM renderers

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import EventEmitter from './utils/EventEmitter';
 import * as PropTypes from './propTypes';
 import inject from './inject';
+import empty from '../empty';
 
 /**
  * dev tool support
@@ -19,7 +20,7 @@ export const componentByNodeRegistery = typeof WeakMap !== "undefined" ? new Wea
 export const renderReporter = new EventEmitter();
 
 function findDOMNode(component) {
-  if (ReactDOM) {
+  if (ReactDOM !== empty) {
     try {
       return ReactDOM.findDOMNode(component);
     } catch (e) {

--- a/src/observer.js
+++ b/src/observer.js
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom';
 import EventEmitter from './utils/EventEmitter';
 import * as PropTypes from './propTypes';
 import inject from './inject';
-import empty from '../empty';
 
 /**
  * dev tool support
@@ -20,7 +19,7 @@ export const componentByNodeRegistery = typeof WeakMap !== "undefined" ? new Wea
 export const renderReporter = new EventEmitter();
 
 function findDOMNode(component) {
-  if (ReactDOM !== empty) {
+  if (ReactDOM && ReactDOM.findDOMNode) {
     try {
       return ReactDOM.findDOMNode(component);
     } catch (e) {


### PR DESCRIPTION
When enabling `trackComponents`, `findDOMNode` was throwing exceptions in the `try...catch` statement when used with non-DOM renderers.
I guess the empty-module behaviour changed when moving from webpack to rollup?