### PR TITLE
Add usless files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,8 @@ publish.js
 *.patch
 src
 webpack.config.js
+*.html
+README.md
+build-rollup.js
+CHANGELOG.md
+.vscode

--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,5 @@ publish.js
 src
 webpack.config.js
 *.html
-README.md
 build-rollup.js
-CHANGELOG.md
 .vscode


### PR DESCRIPTION
Now mobx-react in node_modules contain 16Mb of files like
```
...
1,1M .source.1498822720102.html
2,1M .source.1498822801644.html
1,2M .source.1498823397239.html
2,7M .source.1498824693094.html
2,7M .source.1498824814730.html
2,7M .source.1498825539594.html
2,7M .source.1498827379965.html
...
```
After remove them it use only 316Kb