### PR TITLE
housekeeping: add .prettierrc, .editorconfig, and run prettier on the repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_size = 4
+charset = utf-8
+

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "tabWidth": 4,
+  "semi": false
+}

--- a/build-rollup.js
+++ b/build-rollup.js
@@ -1,95 +1,101 @@
-var path = require('path');
-var filesize = require('rollup-plugin-filesize');
-var babel = require('rollup-plugin-babel');
+var path = require("path")
+var filesize = require("rollup-plugin-filesize")
+var babel = require("rollup-plugin-babel")
 
-var commonjs = require('rollup-plugin-commonjs');
-var resolve = require('rollup-plugin-node-resolve');
+var commonjs = require("rollup-plugin-commonjs")
+var resolve = require("rollup-plugin-node-resolve")
 
-var uglify = require('rollup-plugin-uglify');
-var alias = require('rollup-plugin-alias');
+var uglify = require("rollup-plugin-uglify")
+var alias = require("rollup-plugin-alias")
 
-var {rollup} = require('rollup');
+var { rollup } = require("rollup")
 
-var reactDomModulePath = require.resolve('react-dom');
-var emptyModulePath = path.resolve(__dirname, 'empty.js');
+var reactDomModulePath = require.resolve("react-dom")
+var emptyModulePath = path.resolve(__dirname, "empty.js")
 
 function getExternals(target) {
     switch (target) {
-        case "browser": return ["react", "mobx", "react-dom"]
-        case "native": return  ["react", "mobx", "react-native"]
-        case "custom": return  ["react", "mobx"]
+        case "browser":
+            return ["react", "mobx", "react-dom"]
+        case "native":
+            return ["react", "mobx", "react-native"]
+        case "custom":
+            return ["react", "mobx"]
     }
 }
 
 function getAliases(target) {
     switch (target) {
-        case "browser": return { "react-native": emptyModulePath }
-        case "native": return { "react-dom": emptyModulePath }
-        case "custom": return { "react-native": emptyModulePath, "react-dom": emptyModulePath }
+        case "browser":
+            return { "react-native": emptyModulePath }
+        case "native":
+            return { "react-dom": emptyModulePath }
+        case "custom":
+            return { "react-native": emptyModulePath, "react-dom": emptyModulePath }
     }
 }
 
 function build(target, mode, filename) {
-  let externals;
-  let aliases;
+    let externals
+    let aliases
 
-  var plugins = [
-    alias(getAliases(target)),
-    babel({
-      exclude: 'node_modules/**',
-      presets: ['es2015-rollup', 'react'],
-      plugins: ['transform-decorators-legacy', 'transform-class-properties'],
-    }),
-    resolve({
-      module: true,
-      main: true,
-    }),
-    commonjs(),
-  ];
+    var plugins = [
+        alias(getAliases(target)),
+        babel({
+            exclude: "node_modules/**",
+            presets: ["es2015-rollup", "react"],
+            plugins: ["transform-decorators-legacy", "transform-class-properties"]
+        }),
+        resolve({
+            module: true,
+            main: true
+        }),
+        commonjs()
+    ]
 
-  if (mode.endsWith('.min')) {
-    plugins.push(
-      uglify({
-        ie8: false,
-        warnings: false,
-      })
-    );
-  }
+    if (mode.endsWith(".min")) {
+        plugins.push(
+            uglify({
+                ie8: false,
+                warnings: false
+            })
+        )
+    }
 
-  plugins.push(filesize());
+    plugins.push(filesize())
 
-  return rollup({
-    input: 'src/index.js',
-    external: getExternals(target),
-    plugins: plugins,
-  })
-    .then(function(bundle) {
-      var options = {
-        file: path.resolve(__dirname, filename),
-        format: mode.endsWith(".min") ? mode.slice(0, -".min".length) : mode,
-        name: 'mobxReact',
-        exports: 'named',
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          'react-native': 'ReactNative',
-          mobx: 'mobx',
-        },
-      };
-
-      return bundle.write(options);
+    return rollup({
+        input: "src/index.js",
+        external: getExternals(target),
+        plugins: plugins
     })
-    .catch(function(reason) {
-      console.error(reason);
-      process.exit(-1);
-    });
+        .then(function(bundle) {
+            var options = {
+                file: path.resolve(__dirname, filename),
+                format: mode.endsWith(".min") ? mode.slice(0, -".min".length) : mode,
+                name: "mobxReact",
+                exports: "named",
+                globals: {
+                    react: "React",
+                    "react-dom": "ReactDOM",
+                    "react-native": "ReactNative",
+                    mobx: "mobx"
+                }
+            }
+
+            return bundle.write(options)
+        })
+        .catch(function(reason) {
+            console.error(reason)
+            process.exit(-1)
+        })
 }
 
 Promise.all([
-    build('browser', 'umd', 'index.js'),
-    build('browser', 'umd.min', 'index.min.js'),
-    build('browser', 'es', 'index.module.js'),
-    build('native', 'es', 'native.js'),
-    build('custom', 'umd', 'custom.js'),
-    build('custom', 'es', 'custom.module.js')
-]);
+    build("browser", "umd", "index.js"),
+    build("browser", "umd.min", "index.min.js"),
+    build("browser", "es", "index.module.js"),
+    build("native", "es", "native.js"),
+    build("custom", "umd", "custom.js"),
+    build("custom", "es", "custom.module.js")
+])

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/mobxjs/mobx-react.git"
   },
   "scripts": {
-    "prettier": "prettier --write --print-width 100 --tab-width 4 --no-semi \"**/*.js\" \"**/*.ts\"",
+    "prettier": "prettier --write \"**/*.js\" \"**/*.ts\"",
     "test": "npm run build && npm run test:console && npm run test:ts",
     "test:ts": "tsc -p test/ts",
     "test:build": "browserify -x react/addons -x react-native -x react/lib/ReactContext -x react/lib/ExecutionEnvironment test/index.js -o ./test/browser/test_bundle.js -t [ babelify --presets [ es2015 react ] --plugins [ transform-decorators-legacy transform-class-properties ] ]",

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,13 @@
-import {extras, spy} from 'mobx';
-import { Component } from 'react';
-import {unstable_batchedUpdates as rdBatched} from 'react-dom';
-import {unstable_batchedUpdates as rnBatched} from 'react-native';
+import { extras, spy } from "mobx"
+import { Component } from "react"
+import { unstable_batchedUpdates as rdBatched } from "react-dom"
+import { unstable_batchedUpdates as rnBatched } from "react-native"
 
-if (!Component)
-  throw new Error('mobx-react requires React to be available');
-if (!extras)
-  throw new Error('mobx-react requires mobx to be available');
+if (!Component) throw new Error("mobx-react requires React to be available")
+if (!extras) throw new Error("mobx-react requires mobx to be available")
 
-if (typeof rdBatched === "function")
-  extras.setReactionScheduler(rdBatched);
-else if (typeof rnBatched === "function")
-  extras.setReactionScheduler(rnBatched);
+if (typeof rdBatched === "function") extras.setReactionScheduler(rdBatched)
+else if (typeof rnBatched === "function") extras.setReactionScheduler(rnBatched)
 
 export {
     observer,
@@ -35,9 +31,9 @@ export const onError = fn => errorsReporter.on(fn)
 /* DevTool support */
 // See: https://github.com/andykog/mobx-devtools/blob/d8976c24b8cb727ed59f9a0bc905a009df79e221/src/backend/installGlobalHook.js
 
-import { renderReporter, componentByNodeRegistery, trackComponents } from './observer';
-if (typeof __MOBX_DEVTOOLS_GLOBAL_HOOK__ === 'object') {
-  const mobx = { spy, extras };
-  const mobxReact = { renderReporter, componentByNodeRegistery, trackComponents };
-  __MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobxReact(mobxReact, mobx);
+import { renderReporter, componentByNodeRegistery, trackComponents } from "./observer"
+if (typeof __MOBX_DEVTOOLS_GLOBAL_HOOK__ === "object") {
+    const mobx = { spy, extras }
+    const mobxReact = { renderReporter, componentByNodeRegistery, trackComponents }
+    __MOBX_DEVTOOLS_GLOBAL_HOOK__.injectMobxReact(mobxReact, mobx)
 }

--- a/test/ErrorCatcher.js
+++ b/test/ErrorCatcher.js
@@ -1,29 +1,29 @@
-import React from "react";
+import React from "react"
 
 // FIXME: saddly, this does not work as hoped, see: https://github.com/facebook/react/issues/10474#issuecomment-332810203
 export default class ErrorCatcher extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  componentDidCatch(error, info) {
-    console.error("Caught react error", error, info);
-    ErrorCatcher.lastError = "" + error;
-    this.setState({ hasError: true });
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return null;
+    constructor(props) {
+        super(props)
+        this.state = { hasError: false }
     }
-    return this.props.children;
-  }
+
+    componentDidCatch(error, info) {
+        console.error("Caught react error", error, info)
+        ErrorCatcher.lastError = "" + error
+        this.setState({ hasError: true })
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return null
+        }
+        return this.props.children
+    }
 }
 
-ErrorCatcher.lastError = "";
+ErrorCatcher.lastError = ""
 ErrorCatcher.getError = function() {
-  const res = ErrorCatcher.lastError;
-  ErrorCatcher.lastError = "";
-  return res;
-};
+    const res = ErrorCatcher.lastError
+    ErrorCatcher.lastError = ""
+    return res
+}

--- a/test/context.js
+++ b/test/context.js
@@ -1,5 +1,5 @@
 import React from "react"
-import createClass from "create-react-class";
+import createClass from "create-react-class"
 import { mount } from "enzyme"
 import test from "tape"
 import mobx from "mobx"
@@ -108,17 +108,18 @@ test("observer based context", t => {
                 throw new Error("Oops")
             }
         })
-        const B = () => <ErrorCatcher><C /></ErrorCatcher>
+        const B = () => (
+            <ErrorCatcher>
+                <C />
+            </ErrorCatcher>
+        )
         console.log("About to mount")
         mount(<B />)
         console.log("mounted")
-        setTimeout(
-            () => {
-                t.ok(/Oops/.test(ErrorCatcher.getError()))
-                t.end()
-            },
-            100
-        )
+        setTimeout(() => {
+            t.ok(/Oops/.test(ErrorCatcher.getError()))
+            t.end()
+        }, 100)
     })
 
     test.skip("store should be available", t => {
@@ -130,14 +131,22 @@ test("observer based context", t => {
                 }
             })
         )
-        const B = () => <ErrorCatcher><C /></ErrorCatcher>
+        const B = () => (
+            <ErrorCatcher>
+                <C />
+            </ErrorCatcher>
+        )
         const A = () => (
             <Provider baz={42}>
                 <B />
             </Provider>
         )
         mount(<A />)
-        t.ok(/Store 'foo' is not available! Make sure it is provided by some Provider/.test(ErrorCatcher.getError()))
+        t.ok(
+            /Store 'foo' is not available! Make sure it is provided by some Provider/.test(
+                ErrorCatcher.getError()
+            )
+        )
         t.end()
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { configure } from "enzyme"
+import Adapter from "enzyme-adapter-react-16"
 
-configure({ adapter: new Adapter() });
+configure({ adapter: new Adapter() })
 
 export function createTestRoot() {
     if (!window.document.body) {

--- a/test/inject.js
+++ b/test/inject.js
@@ -1,5 +1,5 @@
 import React from "react"
-import * as PropTypes from 'prop-types'
+import * as PropTypes from "prop-types"
 import createClass from "create-react-class"
 import ReactDOM from "react-dom"
 import { mount } from "enzyme"

--- a/test/issue21.js
+++ b/test/issue21.js
@@ -50,7 +50,8 @@ const Wizard = observer(
     createClass({
         displayName: "Wizard",
         render() {
-            return createElement("div",
+            return createElement(
+                "div",
                 null,
                 <div>
                     <h1>Active Step: </h1>
@@ -77,7 +78,11 @@ const WizardSteps = observer(
         },
         render() {
             var steps = _.map(this.props.steps, step =>
-                createElement("div", { key: step.title }, <WizardStep step={step} key={step.title} />)
+                createElement(
+                    "div",
+                    { key: step.title },
+                    <WizardStep step={step} key={step.title} />
+                )
             )
             return createElement("div", null, steps)
         }
@@ -98,7 +103,8 @@ const WizardStep = observer(
             if (this.props.tester === true) {
                 topRenderCount++
             }
-            return createElement("div",
+            return createElement(
+                "div",
                 { onClick: this.modeClickHandler },
                 "RenderCount: " +
                     this.renderCount++ +

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,5 +1,5 @@
 import React, { createElement } from "react"
-import createClass from "create-react-class";
+import createClass from "create-react-class"
 import ReactDOM from "react-dom"
 import { mount, shallow } from "enzyme"
 import test from "tape"
@@ -139,7 +139,7 @@ test("#85 Should handle state changing in constructors", function(t) {
 })
 
 test("testIsComponentReactive", t => {
-    const C = observer(() => null )
+    const C = observer(() => null)
     const wrapper = mount(<C />)
     const instance = wrapper.instance()
 
@@ -165,7 +165,10 @@ test("testGetDNode", t => {
     mobx.extendObservable(wrapper.instance(), {
         x: 3
     })
-    t.notStrictEqual(mobx.extras.getAtom(wrapper.instance(), "x"), mobx.extras.getAtom(wrapper.instance().render))
+    t.notStrictEqual(
+        mobx.extras.getAtom(wrapper.instance(), "x"),
+        mobx.extras.getAtom(wrapper.instance().render)
+    )
 
     t.end()
 })

--- a/test/observer.js
+++ b/test/observer.js
@@ -317,8 +317,11 @@ test("changing state in render should fail", function(t) {
         if (data.get() === 3) {
             try {
                 data.set(4) // wouldn't throw first time for lack of observers.. (could we tighten this?)
-            } catch(err) {
-                t.true(/Side effects like changing state are not allowed at this point/.test(err), "Unexpected error: " + err)
+            } catch (err) {
+                t.true(
+                    /Side effects like changing state are not allowed at this point/.test(err),
+                    "Unexpected error: " + err
+                )
             }
         }
         return <div>{data.get()}</div>
@@ -326,7 +329,7 @@ test("changing state in render should fail", function(t) {
 
     ReactDOM.render(<Comp />, testRoot, () => {
         data.set(3) // cause throw
-        setTimeout(()=> {
+        setTimeout(() => {
             mobx.extras.resetGlobalState()
             t.end()
         }, 200)
@@ -462,7 +465,7 @@ test("should render component even if setState called with exactly the same prop
     ReactDOM.render(<Component />, testRoot, () => {
         t.equal(renderCount, 1, "renderCount === 1")
         testRoot.querySelector("#clickableDiv").click()
-        setTimeout(()=> {
+        setTimeout(() => {
             t.equal(renderCount, 2, "renderCount === 2")
             testRoot.querySelector("#clickableDiv").click()
             setTimeout(() => {

--- a/test/propTypes.js
+++ b/test/propTypes.js
@@ -6,45 +6,67 @@ import { observable, asMap } from "mobx"
 
 // Cause `checkPropTypes` caches errors and doesn't print them twice....
 // https://github.com/facebook/prop-types/issues/91
-let testComponentId = 0;
+let testComponentId = 0
 
 function typeCheckFail(test, declaration, value, message) {
-    const baseError = console.error;
-    let error = "";
-    console.error = msg => { error = msg }
+    const baseError = console.error
+    let error = ""
+    console.error = msg => {
+        error = msg
+    }
 
     const props = { testProp: value }
     const propTypes = { testProp: declaration }
 
-    const compId = "testComponent" + (++testComponentId)
+    const compId = "testComponent" + ++testComponentId
     ReactPropTypes.checkPropTypes(propTypes, props, "prop", compId, null)
 
     error = error.replace(compId, "testComponent")
-    test.equal(error, "Warning: Failed prop type: "+ message)
+    test.equal(error, "Warning: Failed prop type: " + message)
     console.error = baseError
 }
 
 function typeCheckFailRequiredValues(test, declaration) {
-    const baseError = console.error;
-    let error = "";
-    console.error = msg => { error = msg }
+    const baseError = console.error
+    let error = ""
+    console.error = msg => {
+        error = msg
+    }
 
     const propTypes = { testProp: declaration }
     const specifiedButIsNullMsg = /but its value is `null`\./
-    const unspecifiedMsg =/but its value is `undefined`\./
+    const unspecifiedMsg = /but its value is `undefined`\./
 
     const props1 = { testProp: null }
-    ReactPropTypes.checkPropTypes(propTypes, props1, "testProp", "testComponent" + (++testComponentId), null)
+    ReactPropTypes.checkPropTypes(
+        propTypes,
+        props1,
+        "testProp",
+        "testComponent" + ++testComponentId,
+        null
+    )
     test.ok(specifiedButIsNullMsg.test(error))
 
     error = ""
     const props2 = { testProp: undefined }
-    ReactPropTypes.checkPropTypes(propTypes, props2, "testProp", "testComponent" + (++testComponentId), null)
+    ReactPropTypes.checkPropTypes(
+        propTypes,
+        props2,
+        "testProp",
+        "testComponent" + ++testComponentId,
+        null
+    )
     test.ok(unspecifiedMsg.test(error))
 
     error = ""
     const props3 = {}
-    ReactPropTypes.checkPropTypes(propTypes, props3, "testProp", "testComponent" + (++testComponentId), null)
+    ReactPropTypes.checkPropTypes(
+        propTypes,
+        props3,
+        "testProp",
+        "testComponent" + ++testComponentId,
+        null
+    )
     test.ok(unspecifiedMsg.test(error))
 
     console.error = baseError
@@ -52,7 +74,13 @@ function typeCheckFailRequiredValues(test, declaration) {
 
 function typeCheckPass(test, declaration, value) {
     const props = { testProp: value }
-    const error = ReactPropTypes.checkPropTypes({ testProp: declaration }, props, "testProp", "testComponent" + (++testComponentId), null)
+    const error = ReactPropTypes.checkPropTypes(
+        { testProp: declaration },
+        props,
+        "testProp",
+        "testComponent" + ++testComponentId,
+        null
+    )
     test.equal(error, undefined)
 }
 

--- a/test/stateless.js
+++ b/test/stateless.js
@@ -1,5 +1,5 @@
 import React, { createElement } from "react"
-import * as PropTypes from 'prop-types'
+import * as PropTypes from "prop-types"
 import createClass from "create-react-class"
 import ReactDOM from "react-dom"
 import test from "tape"


### PR DESCRIPTION
* Moves the prettier config from the command line in the `prettier` npm task to `.prettierrc`
  - This allows editors such as Visual Studio Code to take advantage of that file and set formatting settings appropriately.
* Also add .editorconfig for consistency
* Run the `prettier` npm task to bring the code-base formatting up to snuff