### PR TITLE
Add `displayName` to Observer component

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -340,6 +340,8 @@ function mixinLifecycleEvents(target) {
 // TODO: support injection somehow as well?
 export const Observer = observer(({ children }) => children())
 
+Observer.displayName = "Observer"
+
 Observer.propTypes = {
     children: (propValue, key, componentName, location, propFullName) => {
         if (typeof propValue[key] !== "function")


### PR DESCRIPTION
Hello,

The Observer component renders improperly in React dev tools:

| Current | After Fix |
| -----|----|
| ![image](https://user-images.githubusercontent.com/3587605/31313103-6208df84-aba6-11e7-8147-d135f0873e7c.png) | ![image](https://user-images.githubusercontent.com/3587605/31313109-7066fc32-aba6-11e7-9855-e1efc585f6b9.png) | 

The fix was a super simple one-liner.
