### PR TITLE
Remove void from React.ComponentClass<P | void>

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,7 +25,7 @@ export function observer<P>(
 
 export function observer<P>(clazz: IReactComponent<P>): React.ClassicComponentClass<P>
 export function observer<P>(clazz: React.ClassicComponentClass<P>): React.ClassicComponentClass<P>
-export function observer<P, TFunction extends React.ComponentClass<P | void>>(
+export function observer<P, TFunction extends React.ComponentClass<P>>(
     target: TFunction
 ): TFunction // decorator signature
 


### PR DESCRIPTION
Not needed anymore thx to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17288 (and btw it was found that `{}` is better than `void` for props).
`void` was introduced by me in #193