### PR TITLE
Update Observer component definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,7 +65,7 @@ export function onError(cb: (error: Error) => void): () => void
 
 export class Provider extends React.Component<any, {}> {}
 
-export class Observer extends React.Component<{ children?: () => React.ReactElement<any> }, {}> {}
+export class Observer extends React.Component<{ children?: () => React.ReactNode }, {}> {}
 
 export function useStaticRendering(value: boolean): void
 


### PR DESCRIPTION
Hi!

Right now we have to wrap observerd value with HTML tag like:

```
const C => <Observer>{() => <div>{obser.vable}</div>}</Observer>
```

With this change you can just return observed value

```
const C => <Observer>{() => obser.vable}</Observer>
```

Thank you!