### PR TITLE
Add husky and run Prettier manually

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "create-react-class": "^15.6.2",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.0.0",
+    "husky": "0.14.3",
     "jest": "^22.0.5",
     "jest-environment-jsdom": "^22.0.5",
     "lint-staged": "^4.2.3",
@@ -85,8 +86,8 @@
     "reactive"
   ],
   "lint-staged": {
-    "*.{ts,tsx,js,jsx}": [
-      "prettier --write --print-width 100 --tab-width 4 --no-semi",
+    "*.{ts,js}": [
+      "prettier --write",
       "git add"
     ]
   },

--- a/src/observer.js
+++ b/src/observer.js
@@ -114,8 +114,8 @@ const reactiveMixin = {
             (this.constructor && (this.constructor.displayName || this.constructor.name)) ||
             "<component>"
         const rootNodeID =
-            this._reactInternalInstance && this._reactInternalInstance._rootNodeID ||
-            this._reactInternalFiber && this._reactInternalFiber._debugID
+            (this._reactInternalInstance && this._reactInternalInstance._rootNodeID) ||
+            (this._reactInternalFiber && this._reactInternalFiber._debugID)
 
         /**
          * If props are shallowly modified, react will render anyway,

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -2,19 +2,18 @@ import React from "react"
 import createClass from "create-react-class"
 import { mount } from "enzyme"
 import mobx from "mobx"
-import {shallow} from 'enzyme';
+import { shallow } from "enzyme"
 import ErrorCatcher from "./ErrorCatcher"
-import { Provider, observer} from '../'
-import { sleepHelper } from './'
-
+import { Provider, observer } from "../"
+import { sleepHelper } from "./"
 
 describe("observer based context", () => {
-    test("jest test",()=>{
+    test("jest test", () => {
         const sum = 1 + 2
         expect(sum).toBe(3)
     })
 
-    test("using observer to inject throws warning", (done) => {
+    test("using observer to inject throws warning", done => {
         const w = console.warn
         const warns = []
         console.warn = msg => warns.push(msg)
@@ -22,7 +21,9 @@ describe("observer based context", () => {
         observer(["test"], () => null)
 
         expect(warns.length).toBe(1)
-        expect(warns[0]).toBe( 'Mobx observer: Using observer to inject stores is deprecated since 4.0. Use `@inject("store1", "store2") @observer ComponentClass` or `inject("store1", "store2")(observer(componentClass))` instead of `@observer(["store1", "store2"]) ComponentClass`')
+        expect(warns[0]).toBe(
+            'Mobx observer: Using observer to inject stores is deprecated since 4.0. Use `@inject("store1", "store2") @observer ComponentClass` or `inject("store1", "store2")(observer(componentClass))` instead of `@observer(["store1", "store2"]) ComponentClass`'
+        )
 
         console.warn = w
         done()
@@ -67,7 +68,7 @@ describe("observer based context", () => {
         expect(wrapper.find("div").text()).toEqual("context:42")
         done()
     })
-    
+
     test("overriding stores is supported", done => {
         const C = observer(
             ["foo", "bar"],
@@ -103,9 +104,9 @@ describe("observer based context", () => {
         done()
     })
 
-     //FIXME: this test works correct, but since React in dev always rethrows exception, it is impossible to prevent tape-run from dying on the uncaught exception
+    //FIXME: this test works correct, but since React in dev always rethrows exception, it is impossible to prevent tape-run from dying on the uncaught exception
     // See: https://github.com/facebook/react/issues/10474#issuecomment-332810203
-    test("ErrorCatcher should work", async() => {
+    test("ErrorCatcher should work", async () => {
         const C = createClass({
             render() {
                 throw new Error("Oops")
@@ -202,7 +203,9 @@ describe("observer based context", () => {
         a.set(42)
         expect(wrapper.find("span").text()).toEqual("42")
         expect(wrapper.find("div").text()).toEqual("context:3")
-        expect(msg).toEqual("MobX Provider: Provided store 'foo' has changed. Please avoid replacing stores as the change might not propagate to all children")
+        expect(msg).toEqual(
+            "MobX Provider: Provided store 'foo' has changed. Please avoid replacing stores as the change might not propagate to all children"
+        )
         console.warn = baseWarn
         done()
     })
@@ -238,7 +241,7 @@ describe("observer based context", () => {
             })
         )
         const wrapper = mount(<A />)
-        expect(wrapper.find("span").text()).toEqual( "3")
+        expect(wrapper.find("span").text()).toEqual("3")
         expect(wrapper.find("div").text()).toEqual("context:3")
         a.set(42)
         expect(wrapper.find("span").text()).toEqual("42")

--- a/test/index.js
+++ b/test/index.js
@@ -14,14 +14,14 @@ export function createTestRoot() {
     return testRoot
 }
 
-export function sleepHelper(time){
-   return new Promise((resolve)=>{
-       setTimeout(resolve, time);
-   })
+export function sleepHelper(time) {
+    return new Promise(resolve => {
+        setTimeout(resolve, time)
+    })
 }
 
-export function asyncReactDOMRender(Component,root){
-    return new Promise((resolve)=>{
+export function asyncReactDOMRender(Component, root) {
+    return new Promise(resolve => {
         ReactDOM.render(Component, root, resolve)
     })
 }

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -6,7 +6,7 @@ import { mount } from "enzyme"
 import mobx, { action, observable, computed } from "mobx"
 import { observer, inject, Provider } from "../"
 import { createTestRoot } from "./index"
-import { sleepHelper } from './index'
+import { sleepHelper } from "./index"
 
 const testRoot = createTestRoot()
 
@@ -108,7 +108,9 @@ describe("inject based context", () => {
                 </Provider>
             )
         })
-        expect(() => mount(<A />)).toThrow(/Store 'foo' is not available! Make sure it is provided by some Provider/)
+        expect(() => mount(<A />)).toThrow(
+            /Store 'foo' is not available! Make sure it is provided by some Provider/
+        )
     })
 
     test("store is not required if prop is available", () => {
@@ -173,23 +175,25 @@ describe("inject based context", () => {
         )
         const wrapper = mount(<A />)
 
-       expect(wrapper.find("span").text()).toBe("3")
-       expect(wrapper.find("div").text()).toBe("context:3")
+        expect(wrapper.find("span").text()).toBe("3")
+        expect(wrapper.find("div").text()).toBe("context:3")
 
         a.set(42)
 
-       expect(wrapper.find("span").text()).toBe("42")
-       expect(wrapper.find("div").text()).toBe("context:3")
-       expect(msg).toBe("MobX Provider: Provided store 'foo' has changed. Please avoid replacing stores as the change might not propagate to all children")
+        expect(wrapper.find("span").text()).toBe("42")
+        expect(wrapper.find("div").text()).toBe("context:3")
+        expect(msg).toBe(
+            "MobX Provider: Provided store 'foo' has changed. Please avoid replacing stores as the change might not propagate to all children"
+        )
 
         console.warn = baseWarn
     })
 
     test("custom storesToProps", () => {
         const C = inject((stores, props, context) => {
-           expect(context).toEqual({ mobxStores: { foo: "bar" } })
-           expect(stores).toEqual({ foo: "bar" })
-           expect(props).toEqual( { baz: 42 })
+            expect(context).toEqual({ mobxStores: { foo: "bar" } })
+            expect(stores).toEqual({ foo: "bar" })
+            expect(props).toEqual({ baz: 42 })
             return {
                 zoom: stores.foo,
                 baz: props.baz * 2
@@ -220,7 +224,7 @@ describe("inject based context", () => {
         expect(wrapper.find("div").text()).toBe("context:bar84")
     })
 
-    test("support static hoisting, wrappedComponent and wrappedInstance", async() => {
+    test("support static hoisting, wrappedComponent and wrappedInstance", async () => {
         class B extends React.Component {
             render() {
                 this.testField = 1
@@ -268,7 +272,9 @@ describe("inject based context", () => {
         )
         mount(<A />)
         expect(msg.length).toBe(1)
-        expect(msg[0]).toBe("Mobx Injector: you are trying to attach `contextTypes` on an component decorated with `inject` (or `observer`) HOC. Please specify the contextTypes on the wrapped component instead. It is accessible through the `wrappedComponent`")
+        expect(msg[0]).toBe(
+            "Mobx Injector: you are trying to attach `contextTypes` on an component decorated with `inject` (or `observer`) HOC. Please specify the contextTypes on the wrapped component instead. It is accessible through the `wrappedComponent`"
+        )
 
         console.warn = baseWarn
     })
@@ -282,7 +288,7 @@ describe("inject based context", () => {
             createClass({
                 displayName: "C",
                 render() {
-                    expect(this.props.y).toEqual( 3)
+                    expect(this.props.y).toEqual(3)
                     expect(this.props.x).toBeUndefined()
                     return null
                 }
@@ -306,8 +312,12 @@ describe("inject based context", () => {
         )
         mount(<A />)
         expect(msg.length).toBe(2)
-        expect( msg[0].split("\n")[0]).toBe( "Warning: Failed prop type: The prop `x` is marked as required in `inject-C-with-foo`, but its value is `undefined`.")
-        expect(msg[1].split("\n")[0]).toBe("Warning: Failed prop type: The prop `a` is marked as required in `C`, but its value is `undefined`.")
+        expect(msg[0].split("\n")[0]).toBe(
+            "Warning: Failed prop type: The prop `x` is marked as required in `inject-C-with-foo`, but its value is `undefined`."
+        )
+        expect(msg[1].split("\n")[0]).toBe(
+            "Warning: Failed prop type: The prop `a` is marked as required in `C`, but its value is `undefined`."
+        )
         console.error = baseError
     })
 
@@ -435,21 +445,21 @@ describe("inject based context", () => {
                 <ListComponent items={items} />
             </Provider>,
             testRoot,
-            async() => {
-               expect(listRender).toBe(1)
-               expect(injectRender).toBe(6)
-               expect(itemRender).toBe(6)
+            async () => {
+                expect(listRender).toBe(1)
+                expect(injectRender).toBe(6)
+                expect(itemRender).toBe(6)
 
                 testRoot.querySelectorAll(".hl_ItemB").forEach(e => e.click())
                 await sleepHelper(20)
                 expect(listRender).toBe(1)
-                expect(injectRender).toBe(12)// ideally, 7
+                expect(injectRender).toBe(12) // ideally, 7
                 expect(itemRender).toBe(7)
 
                 testRoot.querySelectorAll(".hl_ItemF").forEach(e => e.click())
                 await sleepHelper(20)
                 expect(listRender).toBe(1)
-                expect(injectRender).toBe(18)// ideally, 9
+                expect(injectRender).toBe(18) // ideally, 9
                 expect(itemRender).toBe(9)
 
                 testRoot.parentNode.removeChild(testRoot)

--- a/test/issue21.test.js
+++ b/test/issue21.test.js
@@ -124,7 +124,7 @@ const WizardStep = observer(
 
 const changeStep = stepNumber => wizardModel.setActiveStep(wizardModel.steps[stepNumber])
 
-test("verify issue 21", async() => {
+test("verify issue 21", async () => {
     await asyncReactDOMRender(<Wizard model={wizardModel} />, testRoot)
     expect(topRenderCount).toBe(1)
     changeStep(0)
@@ -135,8 +135,7 @@ test("verify issue 21", async() => {
     expect(topRenderCount).toBe(3)
 })
 
-
-test("verify prop changes are picked up", async() => {
+test("verify prop changes are picked up", async () => {
     function createItem(subid, label) {
         const res = mobx.observable({
             id: 1,
@@ -194,23 +193,25 @@ test("verify prop changes are picked up", async() => {
         })
         this.setState({}) // trigger update
     }
-   
+
     await asyncReactDOMRender(<Wrapper />, testRoot)
     expect(events.sort()).toEqual([["compute", 1], ["render", 1, "1.1.hi.0"]].sort())
     events.splice(0)
     testRoot.querySelector("#testDiv").click()
     await sleepHelper(100)
-    expect(events.sort()).toEqual([
-      ["compute", 1],
-      ["react", 1],
-      ["receive", 1, 2],
-      ["update", 1, 2],
-      ["compute", 2],
-      ["render", 2, "1.2.test.0"]
-  ].sort())
+    expect(events.sort()).toEqual(
+        [
+            ["compute", 1],
+            ["react", 1],
+            ["receive", 1, 2],
+            ["update", 1, 2],
+            ["compute", 2],
+            ["render", 2, "1.2.test.0"]
+        ].sort()
+    )
 })
 
-test("verify props is reactive", async()=>{
+test("verify props is reactive", async () => {
     function createItem(subid, label) {
         const res = mobx.observable({
             id: 1,
@@ -288,30 +289,29 @@ test("verify props is reactive", async()=>{
             data.items = [createItem(2, "test")]
         })
     }
-    
+
     await asyncReactDOMRender(<Wrapper />, testRoot)
-    expect(events.sort()).toEqual([
-      ["mount"],
-      ["compute", 1],
-      ["computed label", 1],
-      ["render", 1, "1.1.hi.0", "hi"]
-      ].sort())
-  
+    expect(events.sort()).toEqual(
+        [["mount"], ["compute", 1], ["computed label", 1], ["render", 1, "1.1.hi.0", "hi"]].sort()
+    )
+
     events.splice(0)
     testRoot.querySelector("#testDiv").click()
     await sleepHelper(100)
-    expect(events.sort()).toEqual([
-      ["compute", 1],
-      ["react", 1],
-      ["receive", 1, 2],
-      ["update", 1, 2],
-      ["compute", 2],
-      ["computed label", 2],
-      ["render", 2, "1.2.test.0", "test"]
-  ].sort())
+    expect(events.sort()).toEqual(
+        [
+            ["compute", 1],
+            ["react", 1],
+            ["receive", 1, 2],
+            ["update", 1, 2],
+            ["compute", 2],
+            ["computed label", 2],
+            ["render", 2, "1.2.test.0", "test"]
+        ].sort()
+    )
 })
 
-test("no re-render for shallow equal props", async()=>{
+test("no re-render for shallow equal props", async () => {
     function createItem(subid, label) {
         const res = mobx.observable({
             id: 1,
@@ -370,17 +370,16 @@ test("no re-render for shallow equal props", async()=>{
         data.items[0].label = "hi" // no change.
         data.parentValue = 1 // rerender parent
     }
-    
+
     await asyncReactDOMRender(<Wrapper />, testRoot)
     expect(events.sort()).toEqual([["parent render", 0], ["mount"], ["render", 1, "hi"]].sort())
     events.splice(0)
     testRoot.querySelector("#testDiv").click()
     await sleepHelper(100)
     expect(events.sort()).toEqual([["parent render", 1], ["receive", 1, 1]].sort())
-
 })
 
-test("lifecycle callbacks called with correct arguments", async() => {
+test("lifecycle callbacks called with correct arguments", async () => {
     var Component = observer(
         createClass({
             componentWillReceiveProps(nextProps) {
@@ -399,7 +398,7 @@ test("lifecycle callbacks called with correct arguments", async() => {
                 // "componentWillReceiveProps: nextProps.counter === 1"
                 expect(prevProps.counter).toBe(0)
                 // "componentWillReceiveProps: this.props.counter === 1"
-                expect(this.props.counter).toBe(1)               
+                expect(this.props.counter).toBe(1)
             },
             render() {
                 return (

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -8,169 +8,172 @@ import { createTestRoot } from "./index"
 
 const testRoot = createTestRoot()
 
-describe("custom shouldComponentUpdate is not respected for observable changes (#50)",()=>{
-  describe("(#50)-1",()=>{
-    let called = 0
-    const x = mobx.observable(3)
-    const C = observer(
-        createClass({
-            render: () => <div>value:{x.get()}</div>,
-            shouldComponentUpdate: () => called++
+describe("custom shouldComponentUpdate is not respected for observable changes (#50)", () => {
+    describe("(#50)-1", () => {
+        let called = 0
+        const x = mobx.observable(3)
+        const C = observer(
+            createClass({
+                render: () => <div>value:{x.get()}</div>,
+                shouldComponentUpdate: () => called++
+            })
+        )
+        const wrapper = mount(<C />)
+        test("init div context  === value:3 and shouldUpdate hook did not run ", () => {
+            expect(wrapper.find("div").text()).toBe("value:3")
+            expect(called).toBe(0)
         })
-    )
-    const wrapper = mount(<C />)
-    test("init div context  === value:3 and shouldUpdate hook did not run ",()=>{
-      expect(wrapper.find("div").text()).toBe("value:3")
-      expect(called).toBe(0)
-    })
-    test("update div context === value:42 and shouldUpdate hook did not run  ",()=>{
-      x.set(42)
-      expect(wrapper.find("div").text()).toBe("value:42")
-      expect(called).toBe(0)
-    })
-  })
-  
-  describe("(#50) - 2", () => {
-    // TODO: shouldComponentUpdate is meaningless with observable props...., just show warning in component definition?
-    let called = 0
-    const y = mobx.observable(5)
-    const C = observer(
-        createClass({
-            render() {
-                return <div>value:{this.props.y}</div>
-            },
-            shouldComponentUpdate(nextProps) {
-                called++
-                return nextProps.y !== 42
-            }
+        test("update div context === value:42 and shouldUpdate hook did not run  ", () => {
+            x.set(42)
+            expect(wrapper.find("div").text()).toBe("value:42")
+            expect(called).toBe(0)
         })
-    )
-    const B = observer(
-        createClass({
-            render: () => (
-                <span>
-                    <C y={y.get()} />
-                </span>
-            )
-        })
-    )
-    const wrapper = mount(<B />)
-    test("init div context === value:5",()=>{
-      expect(wrapper.find("div").text()).toBe("value:5")
-      expect(called).toBe(0)
     })
 
-    test("update div context === value:6 and shouldComponentUpdate hook run",()=>{
-      y.set(6)
-      expect(wrapper.find("div").text()).toBe("value:6")
-      expect(called).toBe(1)    
-    })
+    describe("(#50) - 2", () => {
+        // TODO: shouldComponentUpdate is meaningless with observable props...., just show warning in component definition?
+        let called = 0
+        const y = mobx.observable(5)
+        const C = observer(
+            createClass({
+                render() {
+                    return <div>value:{this.props.y}</div>
+                },
+                shouldComponentUpdate(nextProps) {
+                    called++
+                    return nextProps.y !== 42
+                }
+            })
+        )
+        const B = observer(
+            createClass({
+                render: () => (
+                    <span>
+                        <C y={y.get()} />
+                    </span>
+                )
+            })
+        )
+        const wrapper = mount(<B />)
+        test("init div context === value:5", () => {
+            expect(wrapper.find("div").text()).toBe("value:5")
+            expect(called).toBe(0)
+        })
 
-    test("update div context === value:6 and shouldComponentUpdate hook run 2",()=>{
-      y.set(42)
-      // expect(wrapper.find('div').text()).toBe('value:6'); // not updated! TODO: fix
-      expect(called).toBe(2)
+        test("update div context === value:6 and shouldComponentUpdate hook run", () => {
+            y.set(6)
+            expect(wrapper.find("div").text()).toBe("value:6")
+            expect(called).toBe(1)
+        })
+
+        test("update div context === value:6 and shouldComponentUpdate hook run 2", () => {
+            y.set(42)
+            // expect(wrapper.find('div').text()).toBe('value:6'); // not updated! TODO: fix
+            expect(called).toBe(2)
+        })
+
+        test("update div context === value:7 and shouldComponentUpdate hook run 3", () => {
+            y.set(7)
+            expect(wrapper.find("div").text()).toBe("value:7")
+            expect(called).toBe(3)
+        })
     })
-    
-    test("update div context === value:7 and shouldComponentUpdate hook run 3", ()=>{
-      y.set(7)
-      expect(wrapper.find("div").text()).toBe("value:7")
-      expect(called).toBe(3)
-    })
-  })
 })
 
 test("issue mobx 405", () => {
-  function ExampleState() {
-      mobx.extendObservable(this, {
-          name: "test",
-          get greetings() {
-              return "Hello my name is " + this.name
-          }
-      })
-  }
+    function ExampleState() {
+        mobx.extendObservable(this, {
+            name: "test",
+            get greetings() {
+                return "Hello my name is " + this.name
+            }
+        })
+    }
 
-  const ExampleView = observer(
-      createClass({
-          render() {
-              return (
-                  <div>
-                      <input
-                          type="text"
-                          onChange={e => (this.props.exampleState.name = e.target.value)}
-                          value={this.props.exampleState.name}
-                      />
-                      <span>{this.props.exampleState.greetings}</span>
-                  </div>
-              )
-          }
-      })
-  )
+    const ExampleView = observer(
+        createClass({
+            render() {
+                return (
+                    <div>
+                        <input
+                            type="text"
+                            onChange={e => (this.props.exampleState.name = e.target.value)}
+                            value={this.props.exampleState.name}
+                        />
+                        <span>{this.props.exampleState.greetings}</span>
+                    </div>
+                )
+            }
+        })
+    )
 
-  const exampleState = new ExampleState()
-  const wrapper = shallow(<ExampleView exampleState={exampleState} />)
-  expect(wrapper.find("span").text()).toBe("Hello my name is test")
-
+    const exampleState = new ExampleState()
+    const wrapper = shallow(<ExampleView exampleState={exampleState} />)
+    expect(wrapper.find("span").text()).toBe("Hello my name is test")
 })
 
-test("#85 Should handle state changing in constructors", (done)=>{
-  const a = mobx.observable(2)
-  const Child = observer(
-      createClass({
-          displayName: "Child",
-          getInitialState() {
-              a.set(3) // one shouldn't do this!
-              return {}
-          },
-          render: () => <div>child:{a.get()} - </div>
-      })
-  )
-  const ParentWrapper = observer(function Parent() {
-      return (
-          <span>
-              <Child />parent:{a.get()}
-          </span>
-      )
-  })
-  ReactDOM.render(<ParentWrapper />, testRoot, () => {
-      expect(testRoot.getElementsByTagName("span")[0].textContent).toBe("child:3 - parent:2")
-      a.set(5)
-      setTimeout(() => {
-          expect(testRoot.getElementsByTagName("span")[0].textContent).toBe("child:5 - parent:5")
-          a.set(7)
-          setTimeout(() => {
-              expect(testRoot.getElementsByTagName("span")[0].textContent).toBe("child:7 - parent:7")
-              testRoot.parentNode.removeChild(testRoot)
-              done()
-          }, 10)
-      }, 10)
-  })
+test("#85 Should handle state changing in constructors", done => {
+    const a = mobx.observable(2)
+    const Child = observer(
+        createClass({
+            displayName: "Child",
+            getInitialState() {
+                a.set(3) // one shouldn't do this!
+                return {}
+            },
+            render: () => <div>child:{a.get()} - </div>
+        })
+    )
+    const ParentWrapper = observer(function Parent() {
+        return (
+            <span>
+                <Child />parent:{a.get()}
+            </span>
+        )
+    })
+    ReactDOM.render(<ParentWrapper />, testRoot, () => {
+        expect(testRoot.getElementsByTagName("span")[0].textContent).toBe("child:3 - parent:2")
+        a.set(5)
+        setTimeout(() => {
+            expect(testRoot.getElementsByTagName("span")[0].textContent).toBe("child:5 - parent:5")
+            a.set(7)
+            setTimeout(() => {
+                expect(testRoot.getElementsByTagName("span")[0].textContent).toBe(
+                    "child:7 - parent:7"
+                )
+                testRoot.parentNode.removeChild(testRoot)
+                done()
+            }, 10)
+        }, 10)
+    })
 })
 
 test("testIsComponentReactive", () => {
-  const C = observer(() => null)
-  const wrapper = mount(<C />)
-  const instance = wrapper.instance()
+    const C = observer(() => null)
+    const wrapper = mount(<C />)
+    const instance = wrapper.instance()
 
-  expect(C.isMobXReactObserver).toBeTruthy()
-  
-  // instance is something different then the rendering reaction!
-  expect(mobx.isObservable(instance)).toBeFalsy()
-  expect(mobx.isObservable(instance.render)).toBeTruthy()
+    expect(C.isMobXReactObserver).toBeTruthy()
 
-  mobx.extendObservable(instance, {})
-  expect(mobx.isObservable(instance)).toBeTruthy()
+    // instance is something different then the rendering reaction!
+    expect(mobx.isObservable(instance)).toBeFalsy()
+    expect(mobx.isObservable(instance.render)).toBeTruthy()
+
+    mobx.extendObservable(instance, {})
+    expect(mobx.isObservable(instance)).toBeTruthy()
 })
 
 test("testGetDNode", () => {
-  const C = observer(() => null)
+    const C = observer(() => null)
 
-  const wrapper = mount(<C />)
-  expect(wrapper.instance().render.$mobx).toBeTruthy()
-  expect(mobx.extras.getAtom(wrapper.instance().render)).toBeTruthy()
+    const wrapper = mount(<C />)
+    expect(wrapper.instance().render.$mobx).toBeTruthy()
+    expect(mobx.extras.getAtom(wrapper.instance().render)).toBeTruthy()
 
-  mobx.extendObservable(wrapper.instance(), {
-      x: 3
-  })
-  expect(mobx.extras.getAtom(wrapper.instance(), "x")).not.toEqual(mobx.extras.getAtom(wrapper.instance().render))
+    mobx.extendObservable(wrapper.instance(), {
+        x: 3
+    })
+    expect(mobx.extras.getAtom(wrapper.instance(), "x")).not.toEqual(
+        mobx.extras.getAtom(wrapper.instance().render)
+    )
 })

--- a/test/observer.test.js
+++ b/test/observer.test.js
@@ -2,12 +2,11 @@ import React, { createElement, Component } from "react"
 import createClass from "create-react-class"
 import ReactDOM from "react-dom"
 import ReactDOMServer from "react-dom/server"
-import TestUtils from 'react-dom/test-utils'
+import TestUtils from "react-dom/test-utils"
 import * as mobx from "mobx"
 import { observer, inject, onError, offError, useStaticRendering, Observer } from "../"
 import { createTestRoot, sleepHelper, asyncReactDOMRender } from "./index"
 import ErrorCatcher from "./ErrorCatcher"
-
 
 /**
  *  some test suite is too tedious
@@ -17,9 +16,9 @@ const testRoot = createTestRoot()
 
 const getDNode = (obj, prop) => obj.$mobx.values[prop]
 
-const asyncRender = (element,root)=>{
-    return new Promise((resolve)=>{
-       ReactDOM.render(<element/>)
+const asyncRender = (element, root) => {
+    return new Promise(resolve => {
+        ReactDOM.render(<element />)
     })
 }
 
@@ -27,10 +26,10 @@ const asyncRender = (element,root)=>{
  use TestUtils.renderIntoDocument  will re-mounted the component  with with different props
  some misunderstanding will be cause？
 */
-describe("nestedRendering",async()=>{
+describe("nestedRendering", async () => {
     const testRoot = createTestRoot()
 
-    // init element 
+    // init element
     const store = mobx.observable({
         todos: [
             {
@@ -39,13 +38,13 @@ describe("nestedRendering",async()=>{
             }
         ]
     })
-    
+
     let todoItemRenderings = 0
     const TodoItem = observer(function TodoItem(props) {
         todoItemRenderings++
         return <li>|{props.todo.title}</li>
     })
-    
+
     let todoListRenderings = 0
     let todoListWillReactCount = 0
     const TodoList = observer(
@@ -66,15 +65,14 @@ describe("nestedRendering",async()=>{
             }
         })
     )
-   beforeAll(async(done)=>{
-       // the side-effect in  does not views alive when using static rendering test suite
-       useStaticRendering(false)
-       await asyncReactDOMRender(<TodoList/>, testRoot)
-       done()
-   })
-    
-   
-    test("first rendering",()=>{
+    beforeAll(async done => {
+        // the side-effect in  does not views alive when using static rendering test suite
+        useStaticRendering(false)
+        await asyncReactDOMRender(<TodoList />, testRoot)
+        done()
+    })
+
+    test("first rendering", () => {
         expect(todoListRenderings).toBe(1)
         expect(todoListWillReactCount).toBe(0)
         expect(testRoot.querySelectorAll("li").length).toBe(1)
@@ -82,7 +80,7 @@ describe("nestedRendering",async()=>{
         expect(todoItemRenderings).toBe(1)
     })
 
-    test("second rendering with inner store changed",()=>{
+    test("second rendering with inner store changed", () => {
         store.todos[0].title += "a"
         expect(todoListRenderings).toBe(1)
         expect(todoListWillReactCount).toBe(0)
@@ -91,21 +89,25 @@ describe("nestedRendering",async()=>{
         expect(getDNode(store.todos[0], "title").observers.length).toBe(1)
     })
 
-    test("rerendering with outer store added",()=>{
+    test("rerendering with outer store added", () => {
         store.todos.push({
             title: "b",
             completed: true
         })
         expect(testRoot.querySelectorAll("li").length).toBe(2)
-        expect(Array.from(testRoot.querySelectorAll("li")).map(e => e.innerHTML).sort()).toEqual(["|aa","|b"].sort())
+        expect(
+            Array.from(testRoot.querySelectorAll("li"))
+                .map(e => e.innerHTML)
+                .sort()
+        ).toEqual(["|aa", "|b"].sort())
         expect(todoListRenderings).toBe(2)
         expect(todoListWillReactCount).toBe(1)
         expect(todoItemRenderings).toBe(3)
         expect(getDNode(store.todos[1], "title").observers.length).toBe(1)
-        expect(getDNode(store.todos[1], "completed").observers.length).toBe(0)   
+        expect(getDNode(store.todos[1], "completed").observers.length).toBe(0)
     })
 
-    test("rerendering with outer store pop", ()=>{
+    test("rerendering with outer store pop", () => {
         const oldTodo = store.todos.pop()
         expect(todoListRenderings).toBe(3)
         expect(todoListWillReactCount).toBe(2)
@@ -116,7 +118,7 @@ describe("nestedRendering",async()=>{
     })
 })
 
-describe("keep views alive",()=>{
+describe("keep views alive", () => {
     let yCalcCount = 0
     const data = mobx.observable({
         x: 3,
@@ -135,20 +137,20 @@ describe("keep views alive",()=>{
         )
     })
     const element = TestUtils.renderIntoDocument(<TestComponent />)
-    
-    test("init state",()=>{
+
+    test("init state", () => {
         expect(yCalcCount).toBe(1)
-        expect(TestUtils.findRenderedDOMComponentWithTag(element, 'div').innerHTML).toBe('hi6')
+        expect(TestUtils.findRenderedDOMComponentWithTag(element, "div").innerHTML).toBe("hi6")
     })
 
-    test("rerender should not need a recomputation of data.y",()=>{
+    test("rerender should not need a recomputation of data.y", () => {
         data.z = "hello"
         expect(yCalcCount).toBe(1)
-        expect(TestUtils.findRenderedDOMComponentWithTag(element, 'div').innerHTML).toBe('hello6')
+        expect(TestUtils.findRenderedDOMComponentWithTag(element, "div").innerHTML).toBe("hello6")
     })
 })
 
-test("componentWillMount from mixin is run first",()=>{
+test("componentWillMount from mixin is run first", () => {
     const Comp = observer(
         createClass({
             componentWillMount: function() {
@@ -163,7 +165,7 @@ test("componentWillMount from mixin is run first",()=>{
     TestUtils.renderIntoDocument(<Comp />)
 })
 
-describe("does not views alive when using static rendering",()=>{
+describe("does not views alive when using static rendering", () => {
     useStaticRendering(true)
 
     let renderCount = 0
@@ -177,21 +179,21 @@ describe("does not views alive when using static rendering",()=>{
     })
     const element = TestUtils.renderIntoDocument(<TestComponent />)
 
-    test('init state is correct',()=>{
+    test("init state is correct", () => {
         expect(renderCount).toBe(1)
-        expect(TestUtils.findRenderedDOMComponentWithTag(element, 'div').innerHTML).toBe('hi')
+        expect(TestUtils.findRenderedDOMComponentWithTag(element, "div").innerHTML).toBe("hi")
     })
 
-    test('no re-rendering on static rendering',()=>{
+    test("no re-rendering on static rendering", () => {
         data.z = "hello"
-            expect(renderCount).toBe(1)
-            expect(TestUtils.findRenderedDOMComponentWithTag(element, 'div').innerHTML).toBe('hi')
-            expect(getDNode(data, "z").observers.length).toBe(0)
-            useStaticRendering(false)
+        expect(renderCount).toBe(1)
+        expect(TestUtils.findRenderedDOMComponentWithTag(element, "div").innerHTML).toBe("hi")
+        expect(getDNode(data, "z").observers.length).toBe(0)
+        useStaticRendering(false)
     })
 })
 
-describe("issue 12",()=>{
+describe("issue 12", () => {
     const data = mobx.observable({
         selected: "coffee",
         items: [
@@ -222,47 +224,52 @@ describe("issue 12",()=>{
     /** table stateles component */
     const Table = observer(function table() {
         return <div>{data.items.map(item => <Row key={item.name} item={item} />)}</div>
-    }) 
+    })
 
-    beforeAll(async(done)=>{
+    beforeAll(async done => {
         await asyncReactDOMRender(<Table />, testRoot)
         done()
     })
 
-    test("init state is correct",()=>{
-        expect([].map.call(testRoot.querySelectorAll('span'), (tag=>tag.innerHTML)).sort()).toEqual(['coffee!','tea'].sort())
+    test("init state is correct", () => {
+        expect([].map.call(testRoot.querySelectorAll("span"), tag => tag.innerHTML).sort()).toEqual(
+            ["coffee!", "tea"].sort()
+        )
     })
-    
-    test("run transaction",()=>{
+
+    test("run transaction", () => {
         mobx.transaction(() => {
             data.items[1].name = "boe"
             data.items.splice(0, 2, { name: "soup" })
             data.selected = "tea"
         })
-        expect([].map.call(testRoot.querySelectorAll('span'), (tag=>tag.innerHTML)).sort()).toEqual(["soup"])
-       
+        expect(
+            [].map.call(testRoot.querySelectorAll("span"), tag => tag.innerHTML).sort()
+        ).toEqual(["soup"])
     })
 })
 
-test("changing state in render should fail",()=>{
+test("changing state in render should fail", () => {
     const data = mobx.observable(2)
     const Comp = observer(() => {
         if (data.get() === 3) {
             try {
                 data.set(4) // wouldn't throw first time for lack of observers.. (could we tighten this?)
             } catch (err) {
-                expect(/Side effects like changing state are not allowed at this point/.test(err)).toBeTruthy()
+                expect(
+                    /Side effects like changing state are not allowed at this point/.test(err)
+                ).toBeTruthy()
             }
         }
         return <div>{data.get()}</div>
     })
     TestUtils.renderIntoDocument(<Comp />)
-    
+
     data.set(3)
     mobx.extras.resetGlobalState()
 })
 
-test("component should not be inject", ()=>{
+test("component should not be inject", () => {
     const msg = []
     const baseWarn = console.warn
     console.warn = m => msg.push(m)
@@ -307,7 +314,7 @@ test("observer component can be injected", () => {
     console.warn = baseWarn
 })
 
-describe("124 - react to changes in this.props via computed",()=>{
+describe("124 - react to changes in this.props via computed", () => {
     const Comp = observer(
         createClass({
             componentWillMount() {
@@ -336,28 +343,25 @@ describe("124 - react to changes in this.props via computed",()=>{
         }
     })
 
-    beforeAll(async(done)=>{
-        await asyncReactDOMRender(<Parent />,testRoot)
+    beforeAll(async done => {
+        await asyncReactDOMRender(<Parent />, testRoot)
         done()
     })
 
-
-    test('init state is correct',()=>{
-        expect(testRoot.querySelector("span").innerHTML).toBe("x:1")  
+    test("init state is correct", () => {
+        expect(testRoot.querySelector("span").innerHTML).toBe("x:1")
     })
 
-    test('change after click',async()=>{
+    test("change after click", async () => {
         testRoot.querySelector("div").click()
         await sleepHelper(100)
-        expect(
-            testRoot.querySelector("span").innerHTML
-        ).toBe("x:2")  
+        expect(testRoot.querySelector("span").innerHTML).toBe("x:2")
     })
 })
 
-  // Test on skip: since all reactions are now run in batched updates, the original issues can no longer be reproduced
-  //this test case should be deprecated?
-  test.skip("should stop updating if error was thrown in render (#134)", ()=>{
+// Test on skip: since all reactions are now run in batched updates, the original issues can no longer be reproduced
+//this test case should be deprecated?
+test.skip("should stop updating if error was thrown in render (#134)", () => {
     const data = mobx.observable(0)
     let renderingsCount = 0
 
@@ -368,19 +372,19 @@ describe("124 - react to changes in this.props via computed",()=>{
         }
         return <div />
     })
-    
+
     TestUtils.renderIntoDocument(<Comp />)
     expect(data.observers.length).toBe(1)
-        data.set(1)
-        expect(data.set(2)).toThrow("Hello")
-        expect(data.observers.length).toBe(0)
-        data.set(3)
-        data.set(4)
-        data.set(5)
-        expect(renderingsCount).toBe(3)
+    data.set(1)
+    expect(data.set(2)).toThrow("Hello")
+    expect(data.observers.length).toBe(0)
+    data.set(3)
+    data.set(4)
+    data.set(5)
+    expect(renderingsCount).toBe(3)
 })
 
-describe("should render component even if setState called with exactly the same props",()=>{
+describe("should render component even if setState called with exactly the same props", () => {
     let renderCount = 0
     const Component = observer(
         createClass({
@@ -394,30 +398,29 @@ describe("should render component even if setState called with exactly the same 
         })
     )
 
-    beforeAll(async(done)=>{
-        await asyncReactDOMRender(<Component />,testRoot)
+    beforeAll(async done => {
+        await asyncReactDOMRender(<Component />, testRoot)
         done()
     })
 
-    test("renderCount === 1",()=>{
+    test("renderCount === 1", () => {
         expect(renderCount).toBe(1)
     })
-    
-    test("after click once renderCount === 2", async()=>{
-      testRoot.querySelector("#clickableDiv").click()
-      sleepHelper(10)
-      expect(renderCount).toBe(2)
-      
-   })
 
-   test("after click twice renderCount === 3", async()=>{
-      testRoot.querySelector("#clickableDiv").click()
-      sleepHelper(10)
-      expect(renderCount).toBe(3)
- })
+    test("after click once renderCount === 2", async () => {
+        testRoot.querySelector("#clickableDiv").click()
+        sleepHelper(10)
+        expect(renderCount).toBe(2)
+    })
+
+    test("after click twice renderCount === 3", async () => {
+        testRoot.querySelector("#clickableDiv").click()
+        sleepHelper(10)
+        expect(renderCount).toBe(3)
+    })
 })
 
-describe("it rerenders correctly if some props are non-observables - 1",()=>{
+describe("it rerenders correctly if some props are non-observables - 1", () => {
     let renderCount = 0
     let odata = mobx.observable({ x: 1 })
     let data = { y: 1 }
@@ -452,30 +455,30 @@ describe("it rerenders correctly if some props are non-observables - 1",()=>{
         data.y++
         odata.x++
     }
-    
-    beforeAll(async(done)=>{
+
+    beforeAll(async done => {
         await asyncReactDOMRender(<Parent odata={odata} data={data} />, testRoot)
         done()
     })
 
-    test("init renderCount === 1",()=>{
+    test("init renderCount === 1", () => {
         expect(testRoot.querySelector("span").innerHTML).toBe("1-1-1")
     })
 
-    test("after click renderCount === 2", async()=>{
+    test("after click renderCount === 2", async () => {
         testRoot.querySelector("span").click()
         await sleepHelper(10)
         expect(testRoot.querySelector("span").innerHTML).toBe("2-2-2")
     })
-    
-    test("after click twice renderCount === 3",async()=>{
+
+    test("after click twice renderCount === 3", async () => {
         testRoot.querySelector("span").click()
         await sleepHelper(10)
         expect(testRoot.querySelector("span").innerHTML).toBe("3-3-3")
     })
 })
 
-describe("it rerenders correctly if some props are non-observables - 2",()=>{
+describe("it rerenders correctly if some props are non-observables - 2", () => {
     let renderCount = 0
     let odata = mobx.observable({ x: 1 })
 
@@ -509,29 +512,28 @@ describe("it rerenders correctly if some props are non-observables - 2",()=>{
         odata.x++
     }
 
-    beforeAll(async(done)=>{
+    beforeAll(async done => {
         await asyncReactDOMRender(<Parent odata={odata} />, testRoot)
         done()
     })
 
-    test("init renderCount === 1",()=>{
+    test("init renderCount === 1", () => {
         expect(renderCount).toBe(1)
         expect(testRoot.querySelector("span").innerHTML).toBe("1-1")
     })
 
-    test("after click renderCount === 2", async()=>{
+    test("after click renderCount === 2", async () => {
         testRoot.querySelector("span").click()
         await sleepHelper(10)
         expect(testRoot.querySelector("span").innerHTML).toBe("2-2")
     })
 
-    test("after click renderCount === 3", async()=>{
+    test("after click renderCount === 3", async () => {
         testRoot.querySelector("span").click()
         await sleepHelper(10)
         expect(testRoot.querySelector("span").innerHTML).toBe("3-3")
     })
 })
-
 
 describe("Observer regions should react", () => {
     const data = mobx.observable("hi")
@@ -541,26 +543,26 @@ describe("Observer regions should react", () => {
             <li>{data.get()}</li>
         </div>
     )
-        
-        beforeAll(async(done)=>{
-            await asyncReactDOMRender(<Comp />, testRoot)
-            done()
-        })
 
-        test('init state is correct', ()=>{
-            expect(testRoot.querySelector("span").innerHTML).toBe('hi')
-            expect(testRoot.querySelector("li").innerHTML).toBe('hi')
-        })
-       
-        test('set the data to hello',async()=>{
-            data.set("hello")
-            await sleepHelper(10)
-            expect(testRoot.querySelector("span").innerHTML).toBe('hello')
-            expect(testRoot.querySelector("li").innerHTML).toBe('hi')
-        })
+    beforeAll(async done => {
+        await asyncReactDOMRender(<Comp />, testRoot)
+        done()
+    })
+
+    test("init state is correct", () => {
+        expect(testRoot.querySelector("span").innerHTML).toBe("hi")
+        expect(testRoot.querySelector("li").innerHTML).toBe("hi")
+    })
+
+    test("set the data to hello", async () => {
+        data.set("hello")
+        await sleepHelper(10)
+        expect(testRoot.querySelector("span").innerHTML).toBe("hello")
+        expect(testRoot.querySelector("li").innerHTML).toBe("hi")
+    })
 })
 
-describe("Observer should not re-render on shallow equal new props",()=>{
+describe("Observer should not re-render on shallow equal new props", () => {
     let childRendering = 0
     let parentRendering = 0
     const data = { x: 1 }
@@ -576,17 +578,17 @@ describe("Observer should not re-render on shallow equal new props",()=>{
         return <Child data={data} />
     })
 
-    beforeAll(async()=>{
+    beforeAll(async () => {
         await asyncReactDOMRender(<Parent />, testRoot)
     })
 
-    test("init state is correct", ()=>{
+    test("init state is correct", () => {
         expect(parentRendering).toBe(1)
         expect(childRendering).toBe(1)
         expect(testRoot.querySelector("span").innerHTML).toBe("1")
     })
 
-    test("after odata change", async()=>{
+    test("after odata change", async () => {
         odata.y++
         sleepHelper(10)
         expect(parentRendering).toBe(2)
@@ -594,7 +596,6 @@ describe("Observer should not re-render on shallow equal new props",()=>{
         expect(testRoot.querySelector("span").innerHTML).toBe("1")
     })
 })
-
 
 test("parent / childs render in the right order", done => {
     // See: https://jsfiddle.net/gkaemmer/q1kv7hbL/13/
@@ -655,7 +656,7 @@ describe("206 - @observer should produce usefull errors if it throws", () => {
 
     const emmitedErrors = []
     const disposeErrorsHandler = onError(error => emmitedErrors.push(error))
-    
+
     @observer
     class Child extends React.Component {
         render() {
@@ -665,24 +666,23 @@ describe("206 - @observer should produce usefull errors if it throws", () => {
         }
     }
 
-    beforeAll(async(done)=>{
+    beforeAll(async done => {
         await asyncReactDOMRender(<Child />, testRoot)
         done()
     })
-    
-   
-    test('init renderCount should === 1',()=>{
+
+    test("init renderCount should === 1", () => {
         expect(renderCount).toBe(1)
     })
 
-    test('catch exception',()=>{
-        expect(()=>{
+    test("catch exception", () => {
+        expect(() => {
             data.x = 42
         }).toThrow(/Oops!/)
         expect(renderCount).toBe(2)
     })
-    
-    test('component recovers!',async()=>{
+
+    test("component recovers!", async () => {
         await sleepHelper(500)
         data.x = 3
         TestUtils.renderIntoDocument(<Child />)
@@ -691,7 +691,7 @@ describe("206 - @observer should produce usefull errors if it throws", () => {
     })
 })
 
-test("195 - async componentWillMount does not work", async()=>{
+test("195 - async componentWillMount does not work", async () => {
     const renderedValues = []
 
     @observer
@@ -715,7 +715,7 @@ test("195 - async componentWillMount does not work", async()=>{
         }
     }
     TestUtils.renderIntoDocument(<WillMount />)
-    
+
     await sleepHelper(500)
     expect(renderedValues).toEqual([0, 1])
 })
@@ -731,5 +731,7 @@ test.skip("195 - should throw if trying to overwrite lifecycle methods", () => {
             return null
         }
     }
-    expect(TestUtils.renderIntoDocument(<WillMount />)).toThrow(/Cannot assign to read only property 'componentWillMount'/)
+    expect(TestUtils.renderIntoDocument(<WillMount />)).toThrow(
+        /Cannot assign to read only property 'componentWillMount'/
+    )
 })

--- a/test/propTypes.test.js
+++ b/test/propTypes.test.js
@@ -83,7 +83,7 @@ function typeCheckPass(declaration, value) {
     expect(error).toBeUndefined()
 }
 
-test("Valid values", ()=> {
+test("Valid values", () => {
     typeCheckPass(PropTypes.observableArray, observable([]))
     typeCheckPass(PropTypes.observableArrayOf(ReactPropTypes.string), observable([""]))
     typeCheckPass(PropTypes.arrayOrObservableArray, observable([]))
@@ -107,137 +107,135 @@ test("should be implicitly optional and not warn", () => {
 })
 
 test("should warn for missing required values, function (test)", () => {
-  typeCheckFailRequiredValues( PropTypes.observableArray.isRequired, undefined)
-  typeCheckFailRequiredValues(
-      PropTypes.observableArrayOf(ReactPropTypes.string).isRequired,
-      undefined
-  )
-  typeCheckFailRequiredValues( PropTypes.arrayOrObservableArray.isRequired, undefined)
-  typeCheckFailRequiredValues(
-      PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string).isRequired,
-      undefined
-  )
-  typeCheckFailRequiredValues( PropTypes.observableObject.isRequired, undefined)
-  typeCheckFailRequiredValues( PropTypes.objectOrObservableObject.isRequired, undefined)
-  typeCheckFailRequiredValues( PropTypes.observableMap.isRequired, undefined)
+    typeCheckFailRequiredValues(PropTypes.observableArray.isRequired, undefined)
+    typeCheckFailRequiredValues(
+        PropTypes.observableArrayOf(ReactPropTypes.string).isRequired,
+        undefined
+    )
+    typeCheckFailRequiredValues(PropTypes.arrayOrObservableArray.isRequired, undefined)
+    typeCheckFailRequiredValues(
+        PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string).isRequired,
+        undefined
+    )
+    typeCheckFailRequiredValues(PropTypes.observableObject.isRequired, undefined)
+    typeCheckFailRequiredValues(PropTypes.objectOrObservableObject.isRequired, undefined)
+    typeCheckFailRequiredValues(PropTypes.observableMap.isRequired, undefined)
 })
 
 test("should fail date and regexp correctly", () => {
-  typeCheckFail(
-      PropTypes.observableObject,
-      new Date(),
-      "Invalid prop `testProp` of type `date` supplied to " +
-          "`testComponent`, expected `mobx.ObservableObject`."
-  )
-  typeCheckFail(
-      PropTypes.observableArray,
-      /please/,
-      "Invalid prop `testProp` of type `regexp` supplied to " +
-          "`testComponent`, expected `mobx.ObservableArray`."
-  )
+    typeCheckFail(
+        PropTypes.observableObject,
+        new Date(),
+        "Invalid prop `testProp` of type `date` supplied to " +
+            "`testComponent`, expected `mobx.ObservableObject`."
+    )
+    typeCheckFail(
+        PropTypes.observableArray,
+        /please/,
+        "Invalid prop `testProp` of type `regexp` supplied to " +
+            "`testComponent`, expected `mobx.ObservableArray`."
+    )
 })
 
 test("observableArray", () => {
-  typeCheckFail(
-      PropTypes.observableArray,
-      [],
-      "Invalid prop `testProp` of type `array` supplied to " +
-          "`testComponent`, expected `mobx.ObservableArray`."
-  )
-  typeCheckFail(
-      PropTypes.observableArray,
-      "",
-      "Invalid prop `testProp` of type `string` supplied to " +
-          "`testComponent`, expected `mobx.ObservableArray`."
-  )
+    typeCheckFail(
+        PropTypes.observableArray,
+        [],
+        "Invalid prop `testProp` of type `array` supplied to " +
+            "`testComponent`, expected `mobx.ObservableArray`."
+    )
+    typeCheckFail(
+        PropTypes.observableArray,
+        "",
+        "Invalid prop `testProp` of type `string` supplied to " +
+            "`testComponent`, expected `mobx.ObservableArray`."
+    )
 })
 
 test("arrayOrObservableArray", () => {
-  typeCheckFail(
-      PropTypes.arrayOrObservableArray,
-      "",
-      "Invalid prop `testProp` of type `string` supplied to " +
-          "`testComponent`, expected `mobx.ObservableArray` or javascript `array`."
-  )
+    typeCheckFail(
+        PropTypes.arrayOrObservableArray,
+        "",
+        "Invalid prop `testProp` of type `string` supplied to " +
+            "`testComponent`, expected `mobx.ObservableArray` or javascript `array`."
+    )
 })
 
 test("observableObject", () => {
-  typeCheckFail(
-      PropTypes.observableObject,
-      {},
-      "Invalid prop `testProp` of type `object` supplied to " +
-          "`testComponent`, expected `mobx.ObservableObject`."
-  )
-  typeCheckFail(
-      PropTypes.observableObject,
-      "",
-      "Invalid prop `testProp` of type `string` supplied to " +
-          "`testComponent`, expected `mobx.ObservableObject`."
-  )
+    typeCheckFail(
+        PropTypes.observableObject,
+        {},
+        "Invalid prop `testProp` of type `object` supplied to " +
+            "`testComponent`, expected `mobx.ObservableObject`."
+    )
+    typeCheckFail(
+        PropTypes.observableObject,
+        "",
+        "Invalid prop `testProp` of type `string` supplied to " +
+            "`testComponent`, expected `mobx.ObservableObject`."
+    )
 })
 
-
 test("objectOrObservableObject", () => {
-  typeCheckFail(
-      PropTypes.objectOrObservableObject,
-      "",
-      "Invalid prop `testProp` of type `string` supplied to " +
-          "`testComponent`, expected `mobx.ObservableObject` or javascript `object`."
-  )
+    typeCheckFail(
+        PropTypes.objectOrObservableObject,
+        "",
+        "Invalid prop `testProp` of type `string` supplied to " +
+            "`testComponent`, expected `mobx.ObservableObject` or javascript `object`."
+    )
 })
 
 test("observableMap", () => {
-  typeCheckFail(
-      PropTypes.observableMap,
-      {},
-      "Invalid prop `testProp` of type `object` supplied to " +
-          "`testComponent`, expected `mobx.ObservableMap`."
-  )
+    typeCheckFail(
+        PropTypes.observableMap,
+        {},
+        "Invalid prop `testProp` of type `object` supplied to " +
+            "`testComponent`, expected `mobx.ObservableMap`."
+    )
 })
 
 test("observableArrayOf", () => {
-  typeCheckFail(
-      PropTypes.observableArrayOf(ReactPropTypes.string),
-      2,
-      "Invalid prop `testProp` of type `number` supplied to " +
-          "`testComponent`, expected `mobx.ObservableArray`."
-  )
-  typeCheckFail(
-      PropTypes.observableArrayOf(ReactPropTypes.string),
-      observable([2]),
-      "Invalid prop `testProp[0]` of type `number` supplied to " +
-          "`testComponent`, expected `string`."
-  )
-  typeCheckFail(
-      PropTypes.observableArrayOf({ foo: PropTypes.string }),
-      { foo: "bar" },
-      "Property `testProp` of component `testComponent` has invalid PropType notation."
-  )
+    typeCheckFail(
+        PropTypes.observableArrayOf(ReactPropTypes.string),
+        2,
+        "Invalid prop `testProp` of type `number` supplied to " +
+            "`testComponent`, expected `mobx.ObservableArray`."
+    )
+    typeCheckFail(
+        PropTypes.observableArrayOf(ReactPropTypes.string),
+        observable([2]),
+        "Invalid prop `testProp[0]` of type `number` supplied to " +
+            "`testComponent`, expected `string`."
+    )
+    typeCheckFail(
+        PropTypes.observableArrayOf({ foo: PropTypes.string }),
+        { foo: "bar" },
+        "Property `testProp` of component `testComponent` has invalid PropType notation."
+    )
 })
 
 test("arrayOrObservableArrayOf", () => {
-  typeCheckFail(
-      PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
-      2,
-      "Invalid prop `testProp` of type `number` supplied to " +
-          "`testComponent`, expected `mobx.ObservableArray` or javascript `array`."
-  )
-  typeCheckFail(
-      PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
-      observable([2]),
-      "Invalid prop `testProp[0]` of type `number` supplied to " +
-          "`testComponent`, expected `string`."
-  )
-  typeCheckFail(
-      PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
-      [2],
-      "Invalid prop `testProp[0]` of type `number` supplied to " +
-          "`testComponent`, expected `string`."
-  )
-  typeCheckFail(
-      PropTypes.arrayOrObservableArrayOf({ foo: PropTypes.string }),
-      { foo: "bar" },
-      "Property `testProp` of component `testComponent` has invalid PropType notation."
-  )
+    typeCheckFail(
+        PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
+        2,
+        "Invalid prop `testProp` of type `number` supplied to " +
+            "`testComponent`, expected `mobx.ObservableArray` or javascript `array`."
+    )
+    typeCheckFail(
+        PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
+        observable([2]),
+        "Invalid prop `testProp[0]` of type `number` supplied to " +
+            "`testComponent`, expected `string`."
+    )
+    typeCheckFail(
+        PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
+        [2],
+        "Invalid prop `testProp[0]` of type `number` supplied to " +
+            "`testComponent`, expected `string`."
+    )
+    typeCheckFail(
+        PropTypes.arrayOrObservableArrayOf({ foo: PropTypes.string }),
+        { foo: "bar" },
+        "Property `testProp` of component `testComponent` has invalid PropType notation."
+    )
 })
-

--- a/test/stateless.test.js
+++ b/test/stateless.test.js
@@ -2,7 +2,7 @@ import React, { createElement } from "react"
 import * as PropTypes from "prop-types"
 import createClass from "create-react-class"
 import ReactDOM from "react-dom"
-import TestUtils from 'react-dom/test-utils'
+import TestUtils from "react-dom/test-utils"
 import * as mobx from "mobx"
 import { observer, propTypes } from "../"
 import { createTestRoot } from "./index"
@@ -18,23 +18,27 @@ stateLessComp.defaultProps = {
     testProp: "default value for prop testProp"
 }
 
-describe("stateless component with propTypes",()=>{
-  const StatelessCompObserver = observer(stateLessComp)
-  test("default property value should be propagated",()=>{
-    expect(StatelessCompObserver.defaultProps.testProp).toBe("default value for prop testProp")
-  })
-  const originalConsoleError = console.error
-  let beenWarned = false
-  console.error = () => (beenWarned = true)
-  const wrapper = <StatelessCompObserver testProp={10} />
-  console.error = originalConsoleError
-  test("an error should be logged with a property type warning", () => {
-    expect(beenWarned).toBeTruthy()
+describe("stateless component with propTypes", () => {
+    const StatelessCompObserver = observer(stateLessComp)
+    test("default property value should be propagated", () => {
+        expect(StatelessCompObserver.defaultProps.testProp).toBe("default value for prop testProp")
     })
-  test("render test correct",()=>{
-    const component = TestUtils.renderIntoDocument(<StatelessCompObserver testProp="hello world" />)
-    expect(TestUtils.findRenderedDOMComponentWithTag(component, "div").innerHTML).toBe("result: hello world")
-  })
+    const originalConsoleError = console.error
+    let beenWarned = false
+    console.error = () => (beenWarned = true)
+    const wrapper = <StatelessCompObserver testProp={10} />
+    console.error = originalConsoleError
+    test("an error should be logged with a property type warning", () => {
+        expect(beenWarned).toBeTruthy()
+    })
+    test("render test correct", () => {
+        const component = TestUtils.renderIntoDocument(
+            <StatelessCompObserver testProp="hello world" />
+        )
+        expect(TestUtils.findRenderedDOMComponentWithTag(component, "div").innerHTML).toBe(
+            "result: hello world"
+        )
+    })
 })
 
 test("stateless component with context support", () => {
@@ -48,8 +52,9 @@ test("stateless component with context support", () => {
         render: () => <StateLessCompWithContextObserver />
     })
     const component = TestUtils.renderIntoDocument(<ContextProvider />)
-    expect(TestUtils.findRenderedDOMComponentWithTag(component, "div").innerHTML.replace(/\n/, ""))
-          .toBe("context: hello world")
+    expect(
+        TestUtils.findRenderedDOMComponentWithTag(component, "div").innerHTML.replace(/\n/, "")
+    ).toBe("context: hello world")
 })
 
 test("component with observable propTypes", () => {

--- a/test/transactions.test.js
+++ b/test/transactions.test.js
@@ -1,13 +1,12 @@
 import React from "react"
 import createClass from "create-react-class"
 import ReactDOM from "react-dom"
-import TestUtils from 'react-dom/test-utils'
+import TestUtils from "react-dom/test-utils"
 import * as mobx from "mobx"
 import * as mobxReact from "../"
 import { createTestRoot, sleepHelper, asyncReactDOMRender } from "./index"
 
-
-test("mobx issue 50", async() => {
+test("mobx issue 50", async () => {
     const testRoot = createTestRoot()
     const foo = {
         a: mobx.observable(true),
@@ -32,14 +31,13 @@ test("mobx issue 50", async() => {
             render: () => <div id="x">{[foo.a.get(), foo.b.get(), foo.c.get()].join(",")}</div>
         })
     )
-    
 
-    await asyncReactDOMRender(<Test />,testRoot)
+    await asyncReactDOMRender(<Test />, testRoot)
 
     // In 3 seconds, flip a and b. This will change c.
     await sleepHelper(200)
     flipStuff()
-    
+
     await sleepHelper(400)
     expect(asText).toBe("false:true:true")
     console.log(document.getElementById("x").innerHTML)
@@ -47,7 +45,7 @@ test("mobx issue 50", async() => {
     expect(willReactCount).toBe(1)
 })
 
-test("React.render should respect transaction", async() => {
+test("React.render should respect transaction", async () => {
     const testRoot = createTestRoot()
     const a = mobx.observable(2)
     const loaded = mobx.observable(false)
@@ -58,22 +56,22 @@ test("React.render should respect transaction", async() => {
         if (loaded.get()) return <div>{a.get()}</div>
         else return <div>loading</div>
     })
-    
-    await asyncReactDOMRender(<Component />,testRoot)
+
+    await asyncReactDOMRender(<Component />, testRoot)
 
     mobx.transaction(() => {
         a.set(3)
         a.set(4)
         loaded.set(true)
     })
-    
+
     await sleepHelper(400)
     expect(testRoot.textContent.replace(/\s+/g, "")).toBe("4")
     expect(valuesSeen.sort()).toEqual([2, 4].sort())
     testRoot.parentNode.removeChild(testRoot)
 })
 
-test("React.render in transaction should succeed", async() => {
+test("React.render in transaction should succeed", async () => {
     const testRoot = createTestRoot()
     const a = mobx.observable(2)
     const loaded = mobx.observable(false)
@@ -90,7 +88,7 @@ test("React.render in transaction should succeed", async() => {
         a.set(4)
         loaded.set(true)
     })
-    
+
     await sleepHelper(400)
     expect(testRoot.textContent.replace(/\s+/g, "")).toBe("4")
     expect(valuesSeen.sort()).toEqual([3, 4].sort())

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,6 @@
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
 
-"@types/node@^7.0.18":
-  version "7.0.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.33.tgz#ae3c53ad01d7e9d62c7f1a85c5f7500d59b9d25b"
-
 "@types/prop-types@^15.5.2":
   version "15.5.2"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"
@@ -42,13 +38,6 @@
 "@types/react@*", "@types/react@^16.0.13":
   version "16.0.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.19.tgz#f804a0fcd6d94c17df92cf2fd46671bbbc862329"
-
-JSONStream@^1.0.3:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
 
 abab@^1.0.3:
   version "1.0.4"
@@ -70,10 +59,6 @@ acorn-globals@^4.0.0:
   resolved "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
   dependencies:
     acorn "^5.0.0"
-
-acorn@^4.0.3:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0, acorn@^5.1.2:
   version "5.3.0"
@@ -205,21 +190,9 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
-array-filter@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
-
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-
-array-map@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
-
-array-reduce@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -229,17 +202,9 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@^2.0.0, asap@~2.0.3:
+asap@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
-
-asn1.js@^4.0.0:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.9.1.tgz#48ba240b45a9280e94748990ba597d216617fd40"
-  dependencies:
-    bn.js "^4.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
 
 asn1@~0.2.3:
   version "0.2.3"
@@ -253,21 +218,9 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assert@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
-  dependencies:
-    util "0.10.3"
-
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-
-astw@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/astw/-/astw-2.2.0.tgz#7bd41784d32493987aeb239b6b4e1c57a873b917"
-  dependencies:
-    acorn "^4.0.3"
 
 async@^1.4.0:
   version "1.5.2"
@@ -1025,10 +978,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base64-js@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
-
 basic-auth@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.0.tgz#015db3f353e02e56377755f962742e8981e7bbba"
@@ -1050,10 +999,6 @@ block-stream@*:
 bluebird@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
-
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.7"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.7.tgz#ddb048e50d9482790094c13eb3fcfc833ce7ab46"
 
 boolbase@~1.0.0:
   version "1.0.0"
@@ -1116,161 +1061,15 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-brorand@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-
-browser-launcher@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/browser-launcher/-/browser-launcher-1.0.0.tgz#0cf0ff1ecdcb7516c8f973bf82eb6f3bf929ce97"
-  dependencies:
-    headless "~0.1.3"
-    merge "~1.0.0"
-    minimist "0.0.5"
-    mkdirp "~0.3.3"
-    plist "0.2.1"
-    xtend "^4.0.0"
-
-browser-pack@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/browser-pack/-/browser-pack-6.0.2.tgz#f86cd6cef4f5300c8e63e07a4d512f65fbff4531"
-  dependencies:
-    JSONStream "^1.0.3"
-    combine-source-map "~0.7.1"
-    defined "^1.0.0"
-    through2 "^2.0.0"
-    umd "^3.0.0"
-
 browser-process-hrtime@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
 
-browser-resolve@^1.11.0, browser-resolve@^1.11.2, browser-resolve@^1.7.0:
+browser-resolve@^1.11.0, browser-resolve@^1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
   dependencies:
     resolve "1.1.7"
-
-browser-run@^3.0.2:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/browser-run/-/browser-run-3.6.1.tgz#cc168aa12cc49230fb576badef2d13e96f8492a0"
-  dependencies:
-    browser-launcher "^1.0.0"
-    duplexer "^0.1.1"
-    ecstatic "^2.0.0"
-    electron-stream "^4.0.0"
-    enstore "^1.0.1"
-    html-inject-script "^1.1.0"
-    optimist "^0.6.1"
-    phantomjs-stream "^1.1.1"
-    server-destroy "^1.0.1"
-    source-map-support "^0.4.0"
-    through "^2.3.8"
-    xhr-write-stream "^0.1.2"
-    xtend "^4.0.1"
-
-browserify-aes@^1.0.0, browserify-aes@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.0.6.tgz#5e7725dbdef1fd5930d4ebab48567ce451c48a0a"
-  dependencies:
-    buffer-xor "^1.0.2"
-    cipher-base "^1.0.0"
-    create-hash "^1.1.0"
-    evp_bytestokey "^1.0.0"
-    inherits "^2.0.1"
-
-browserify-cipher@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.0.tgz#9988244874bf5ed4e28da95666dcd66ac8fc363a"
-  dependencies:
-    browserify-aes "^1.0.4"
-    browserify-des "^1.0.0"
-    evp_bytestokey "^1.0.0"
-
-browserify-des@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.0.tgz#daa277717470922ed2fe18594118a175439721dd"
-  dependencies:
-    cipher-base "^1.0.1"
-    des.js "^1.0.0"
-    inherits "^2.0.1"
-
-browserify-rsa@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
-  dependencies:
-    bn.js "^4.1.0"
-    randombytes "^2.0.1"
-
-browserify-sign@^4.0.0:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.0.4.tgz#aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298"
-  dependencies:
-    bn.js "^4.1.1"
-    browserify-rsa "^4.0.0"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.2"
-    elliptic "^6.0.0"
-    inherits "^2.0.1"
-    parse-asn1 "^5.0.0"
-
-browserify-zlib@~0.1.2:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
-  dependencies:
-    pako "~0.2.0"
-
-browserify@^14.3.0:
-  version "14.4.0"
-  resolved "https://registry.yarnpkg.com/browserify/-/browserify-14.4.0.tgz#089a3463af58d0e48d8cd4070b3f74654d5abca9"
-  dependencies:
-    JSONStream "^1.0.3"
-    assert "^1.4.0"
-    browser-pack "^6.0.1"
-    browser-resolve "^1.11.0"
-    browserify-zlib "~0.1.2"
-    buffer "^5.0.2"
-    cached-path-relative "^1.0.0"
-    concat-stream "~1.5.1"
-    console-browserify "^1.1.0"
-    constants-browserify "~1.0.0"
-    crypto-browserify "^3.0.0"
-    defined "^1.0.0"
-    deps-sort "^2.0.0"
-    domain-browser "~1.1.0"
-    duplexer2 "~0.1.2"
-    events "~1.1.0"
-    glob "^7.1.0"
-    has "^1.0.0"
-    htmlescape "^1.1.0"
-    https-browserify "^1.0.0"
-    inherits "~2.0.1"
-    insert-module-globals "^7.0.0"
-    labeled-stream-splicer "^2.0.0"
-    module-deps "^4.0.8"
-    os-browserify "~0.1.1"
-    parents "^1.0.1"
-    path-browserify "~0.0.0"
-    process "~0.11.0"
-    punycode "^1.3.2"
-    querystring-es3 "~0.2.0"
-    read-only-stream "^2.0.0"
-    readable-stream "^2.0.2"
-    resolve "^1.1.4"
-    shasum "^1.0.0"
-    shell-quote "^1.6.1"
-    stream-browserify "^2.0.0"
-    stream-http "^2.0.0"
-    string_decoder "~1.0.0"
-    subarg "^1.0.0"
-    syntax-error "^1.1.1"
-    through2 "^2.0.0"
-    timers-browserify "^1.0.1"
-    tty-browserify "~0.0.0"
-    url "~0.11.0"
-    util "~0.10.1"
-    vm-browserify "~0.0.1"
-    xtend "^4.0.0"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -1278,32 +1077,13 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-xor@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
-
-buffer@^5.0.2:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.6.tgz#2ea669f7eec0b6eda05b08f8b5ff661b28573588"
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
 builtin-modules@^1.0.0, builtin-modules@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-builtin-status-codes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
-
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
-
-cached-path-relative@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.1.tgz#d09c4b52800aa4c078e2dd81a869aac90d2e54e7"
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -1392,12 +1172,6 @@ ci-info@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
 
-cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz#eeabf194419ce900da3018c207d212f2a6df0a07"
-  dependencies:
-    inherits "^2.0.1"
-
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -1467,15 +1241,6 @@ colors@^1.0.3, colors@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
-combine-source-map@~0.7.1:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/combine-source-map/-/combine-source-map-0.7.2.tgz#0870312856b307a87cc4ac486f3a9a62aeccc09e"
-  dependencies:
-    convert-source-map "~1.1.0"
-    inline-source-map "~0.6.0"
-    lodash.memoize "~3.0.3"
-    source-map "~0.5.3"
-
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -1514,26 +1279,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
-concat-stream@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-0.1.1.tgz#d7f4e278b90cfc4f0f3ef77fe4c03b40eb3f7900"
-
-concat-stream@~1.5.0, concat-stream@~1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
-  dependencies:
-    inherits "~2.0.1"
-    readable-stream "~2.0.0"
-    typedarray "~0.0.5"
-
 configstore@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.1.tgz#094ee662ab83fad9917678de114faaea8fcdca90"
@@ -1545,19 +1290,9 @@ configstore@^3.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
-console-browserify@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
-  dependencies:
-    date-now "^0.1.4"
-
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-
-constants-browserify@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
 content-type-parser@^1.0.1:
   version "1.0.2"
@@ -1570,10 +1305,6 @@ convert-source-map@^1.4.0:
 convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
-
-convert-source-map@~1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.1.3.tgz#4829c877e9fe49b3161f3bf3673888e204699860"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -1600,38 +1331,11 @@ cosmiconfig@^1.1.0:
     pinkie-promise "^2.0.0"
     require-from-string "^1.1.0"
 
-create-ecdh@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.0.tgz#888c723596cdf7612f6498233eebd7a35301737d"
-  dependencies:
-    bn.js "^4.1.0"
-    elliptic "^6.0.0"
-
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
   dependencies:
     capture-stack-trace "^1.0.0"
-
-create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.3.tgz#606042ac8b9262750f483caddab0f5819172d8fd"
-  dependencies:
-    cipher-base "^1.0.1"
-    inherits "^2.0.1"
-    ripemd160 "^2.0.0"
-    sha.js "^2.4.0"
-
-create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.6.tgz#acb9e221a4e17bdb076e90657c42b93e3726cf06"
-  dependencies:
-    cipher-base "^1.0.3"
-    create-hash "^1.1.0"
-    inherits "^2.0.1"
-    ripemd160 "^2.0.0"
-    safe-buffer "^5.0.1"
-    sha.js "^2.4.8"
 
 create-react-class@^15.6.2:
   version "15.6.2"
@@ -1668,21 +1372,6 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
-crypto-browserify@^3.0.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.11.0.tgz#3652a0906ab9b2a7e0c3ce66a408e957a2485522"
-  dependencies:
-    browserify-cipher "^1.0.0"
-    browserify-sign "^4.0.0"
-    create-ecdh "^4.0.0"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.0"
-    diffie-hellman "^5.0.0"
-    inherits "^2.0.1"
-    pbkdf2 "^3.0.3"
-    public-encrypt "^4.0.0"
-    randombytes "^2.0.0"
-
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -1699,12 +1388,6 @@ css-select@~1.2.0:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
-
-cssauron@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cssauron/-/cssauron-1.4.0.tgz#a6602dff7e04a8306dc0db9a551e92e8b5662ad8"
-  dependencies:
-    through X.X.X
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -1736,23 +1419,13 @@ date-fns@^1.27.2:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
-date-now@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
-
-debug@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  dependencies:
-    ms "0.7.1"
-
 debug@2.6.8, debug@^2.6.0, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.6.1:
+debug@2.6.9, debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1773,10 +1446,6 @@ deep-assign@^2.0.0:
   resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-2.0.0.tgz#ebe06b1f07f08dae597620e3dd1622f371a1c572"
   dependencies:
     is-obj "^1.0.0"
-
-deep-equal@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -1799,10 +1468,6 @@ define-properties@^1.1.2:
     foreach "^2.0.5"
     object-keys "^1.0.8"
 
-defined@^1.0.0, defined@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -1814,22 +1479,6 @@ delegates@^1.0.0:
 depd@1.1.1, depd@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
-
-deps-sort@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/deps-sort/-/deps-sort-2.0.0.tgz#091724902e84658260eb910748cccd1af6e21fb5"
-  dependencies:
-    JSONStream "^1.0.3"
-    shasum "^1.0.0"
-    subarg "^1.0.0"
-    through2 "^2.0.0"
-
-des.js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
-  dependencies:
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -1856,31 +1505,9 @@ detect-port@1.2.1:
     address "^1.0.1"
     debug "^2.6.0"
 
-detective@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/detective/-/detective-4.5.0.tgz#6e5a8c6b26e6c7a254b1c6b6d7490d98ec91edd1"
-  dependencies:
-    acorn "^4.0.3"
-    defined "^1.0.0"
-
-dezalgo@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
-  dependencies:
-    asap "^2.0.0"
-    wrappy "1"
-
 diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
-
-diffie-hellman@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
-  dependencies:
-    bn.js "^4.1.0"
-    miller-rabin "^4.0.0"
-    randombytes "^2.0.0"
 
 discontinuous-range@1.0.0:
   version "1.0.0"
@@ -1892,10 +1519,6 @@ dom-serializer@0, dom-serializer@~0.1.0:
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
-
-domain-browser@~1.1.0:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
 
 domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
@@ -1928,18 +1551,6 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  dependencies:
-    readable-stream "^2.0.2"
-
-duplexer2@~0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
-  dependencies:
-    readable-stream "~1.1.9"
-
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -1948,75 +1559,19 @@ duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
-duplexer@~0.0.2:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.0.4.tgz#afcb7f1f8b8d74f820726171d5d64ac9e4a8ff20"
-
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
 
-ecstatic@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-2.2.1.tgz#b5087fad439dd9dd49d31e18131454817fe87769"
-  dependencies:
-    he "^1.1.1"
-    mime "^1.2.11"
-    minimist "^1.1.0"
-    url-join "^2.0.2"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-download@^3.0.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/electron-download/-/electron-download-3.3.0.tgz#2cfd54d6966c019c4d49ad65fbe65cc9cdef68c8"
-  dependencies:
-    debug "^2.2.0"
-    fs-extra "^0.30.0"
-    home-path "^1.0.1"
-    minimist "^1.2.0"
-    nugget "^2.0.0"
-    path-exists "^2.1.0"
-    rc "^1.1.2"
-    semver "^5.3.0"
-    sumchecker "^1.2.0"
-
-electron-stream@^4.0.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/electron-stream/-/electron-stream-4.2.2.tgz#fc08779c957ef5da95eb7e6209e0b875074509b3"
-  dependencies:
-    debug "^2.6.1"
-    electron "^1.4.4"
-    json-stringify-safe "^5.0.1"
-    stream-read "^1.1.2"
-
-electron@^1.4.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.4.tgz#db8b85ae98dffb7a82938e5ea6eed3cb66f62a65"
-  dependencies:
-    "@types/node" "^7.0.18"
-    electron-download "^3.0.1"
-    extract-zip "^1.0.3"
-
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
-
-elliptic@^6.0.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
-  dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -2027,12 +1582,6 @@ encoding@^0.1.11:
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
-
-enstore@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/enstore/-/enstore-1.0.1.tgz#a20fe71eaebde8a3813a0a1240475f55854a81ab"
-  dependencies:
-    monotonic-timestamp "0.0.8"
 
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
@@ -2083,15 +1632,6 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.5.0, es-abstract@^1.6.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
-  dependencies:
-    es-to-primitive "^1.1.1"
-    function-bind "^1.1.0"
-    is-callable "^1.1.3"
-    is-regex "^1.0.3"
-
 es-abstract@^1.5.1:
   version "1.10.0"
   resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
@@ -2102,6 +1642,15 @@ es-abstract@^1.5.1:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
+es-abstract@^1.6.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    is-callable "^1.1.3"
+    is-regex "^1.0.3"
+
 es-to-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
@@ -2109,10 +1658,6 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
-
-es6-promise@^4.0.5:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -2164,16 +1709,6 @@ esutils@^2.0.0, esutils@^2.0.2:
 etag@~1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
-
-events@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-
-evp_bytestokey@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz#497b66ad9fef65cd7c08a6180824ba1476b66e53"
-  dependencies:
-    create-hash "^1.1.1"
 
 exec-sh@^0.2.0:
   version "0.2.1"
@@ -2265,15 +1800,6 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extract-zip@^1.0.3:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.5.tgz#99a06735b6ea20ea9b705d779acffcc87cff0440"
-  dependencies:
-    concat-stream "1.6.0"
-    debug "2.2.0"
-    mkdirp "0.5.0"
-    yauzl "2.4.1"
-
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
@@ -2308,17 +1834,11 @@ fbjs@^0.8.16, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fd-slicer@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
-  dependencies:
-    pend "~1.2.0"
-
 fibers@^1.0.2:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/fibers/-/fibers-1.0.15.tgz#22f039c8f18b856190fbbe4decf056154c1eae9c"
 
-figures@^1.4.0, figures@^1.7.0:
+figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -2367,12 +1887,6 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-for-each@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
-  dependencies:
-    is-function "~1.0.0"
-
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2419,16 +1933,6 @@ fs-extra@4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2457,7 +1961,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.0, function-bind@~1.1.0:
+function-bind@^1.0.2, function-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
@@ -2534,7 +2038,7 @@ glob@^4.3.2:
     minimatch "^2.0.1"
     once "^1.3.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@~7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2565,7 +2069,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2647,24 +2151,11 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
-has@^1.0.0, has@^1.0.1, has@~1.0.1:
+has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
-
-hash-base@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-2.0.2.tgz#66ea1d856db4e8a5470cadf6fce23ae5244ef2e1"
-  dependencies:
-    inherits "^2.0.1"
-
-hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.2.tgz#bf5c887825cfe40b9efde7bf11bd2db26e6bf01b"
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.0"
 
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
@@ -2683,22 +2174,6 @@ hawk@~6.0.2:
     cryptiles "3.x.x"
     hoek "4.x.x"
     sntp "2.x.x"
-
-he@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-
-headless@~0.1.3:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/headless/-/headless-0.1.7.tgz#6e62fae668947f88184d5c156ede7c5695a7e9c8"
-
-hmac-drbg@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
-  dependencies:
-    hash.js "^1.0.3"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.1"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -2723,10 +2198,6 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-home-path@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.5.tgz#788b29815b12d53bacf575648476e6f9041d133f"
-
 hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
@@ -2736,38 +2207,6 @@ html-encoding-sniffer@^1.0.1:
   resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
-
-html-inject-script@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/html-inject-script/-/html-inject-script-1.1.0.tgz#1a7c10a0fcbd309e85bf53d9a5ed24b74c5e3275"
-  dependencies:
-    trumpet "^1.7.1"
-
-html-select@^2.3.5:
-  version "2.3.24"
-  resolved "https://registry.yarnpkg.com/html-select/-/html-select-2.3.24.tgz#46ad6d712e732cf31c6739d5d0110a5fabf17585"
-  dependencies:
-    cssauron "^1.1.0"
-    duplexer2 "~0.0.2"
-    inherits "^2.0.1"
-    minimist "~0.0.8"
-    readable-stream "^1.0.27-1"
-    split "~0.3.0"
-    stream-splicer "^1.2.0"
-    through2 "^1.0.0"
-
-html-tokenize@^1.1.1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/html-tokenize/-/html-tokenize-1.2.5.tgz#7e5ba99ecb51ef906ec9a7fcdee6ca3267c7897e"
-  dependencies:
-    inherits "~2.0.1"
-    minimist "~0.0.8"
-    readable-stream "~1.0.27-1"
-    through2 "~0.4.1"
-
-htmlescape@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
 
 htmlparser2@^3.9.1:
   version "3.9.2"
@@ -2805,17 +2244,17 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-browserify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
+husky@0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
 
 iconv-lite@0.4.19, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-
-ieee754@^1.1.4:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -2835,10 +2274,6 @@ indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
-indexof@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2846,36 +2281,13 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-
-inherits@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-inline-source-map@~0.6.0:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/inline-source-map/-/inline-source-map-0.6.2.tgz#f9393471c18a79d1724f863fa38b586370ade2a5"
-  dependencies:
-    source-map "~0.5.3"
-
-insert-module-globals@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/insert-module-globals/-/insert-module-globals-7.0.1.tgz#c03bf4e01cb086d5b5e5ace8ad0afe7889d638c3"
-  dependencies:
-    JSONStream "^1.0.3"
-    combine-source-map "~0.7.1"
-    concat-stream "~1.5.1"
-    is-buffer "^1.1.0"
-    lexical-scope "^1.2.0"
-    process "~0.11.0"
-    through2 "^2.0.0"
-    xtend "^4.0.0"
 
 invariant@^2.2.2:
   version "2.2.2"
@@ -2899,7 +2311,7 @@ is-boolean-object@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
 
-is-buffer@^1.1.0, is-buffer@^1.1.5:
+is-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
@@ -2945,7 +2357,7 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
-is-finite@^1.0.0, is-finite@^1.0.1:
+is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
   dependencies:
@@ -2960,10 +2372,6 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-
-is-function@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-generator-fn@^1.0.0:
   version "1.0.0"
@@ -3066,10 +2474,6 @@ is-utf8@^0.2.0:
 is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-
-isarray@0.0.1, isarray@~0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3491,25 +2895,13 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stable-stringify@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz#611c23e814db375527df851193db59dd2af27f45"
-  dependencies:
-    jsonify "~0.0.0"
-
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-jsonfile@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -3520,10 +2912,6 @@ jsonfile@^4.0.0:
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsonparse@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
 
 jsprim@^1.2.2:
   version "1.4.0"
@@ -3545,20 +2933,6 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
-
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  optionalDependencies:
-    graceful-fs "^4.1.9"
-
-labeled-stream-splicer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz#a52e1d138024c00b86b1c0c91f677918b8ae0a59"
-  dependencies:
-    inherits "^2.0.1"
-    isarray "~0.0.1"
-    stream-splicer "^2.0.0"
 
 latest-version@^3.0.0:
   version "3.1.0"
@@ -3590,12 +2964,6 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-lexical-scope@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/lexical-scope/-/lexical-scope-1.2.0.tgz#fcea5edc704a4b3a8796cdca419c3a0afaf22df4"
-  dependencies:
-    astw "^2.0.0"
 
 lint-staged@^4.2.3:
   version "4.2.3"
@@ -3684,17 +3052,9 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
-lodash.memoize@~3.0.3:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-
-lodash@^3.6.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0:
   version "4.17.4"
@@ -3779,7 +3139,7 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-meow@^3.1.0, meow@^3.7.0:
+meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -3803,10 +3163,6 @@ merge-stream@^1.0.1:
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
-
-merge@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.0.0.tgz#b443ab46d837c491e6222056ab0f7933ecb3568f"
 
 micro-compress@1.0.0:
   version "1.0.0"
@@ -3841,13 +3197,6 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-miller-rabin@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.0.tgz#4a62fb1d42933c05583982f4c716f6fb9e6c6d3d"
-  dependencies:
-    bn.js "^4.0.0"
-    brorand "^1.0.1"
-
 "mime-db@>= 1.29.0 < 2", mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
@@ -3858,21 +3207,13 @@ mime-types@2.1.17, mime-types@^2.1.12, mime-types@~2.1.16, mime-types@~2.1.17, m
   dependencies:
     mime-db "~1.30.0"
 
-mime@1.3.4, mime@^1.2.11:
+mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
-
-minimalistic-assert@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
-
-minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
 minimatch@^2.0.1:
   version "2.0.10"
@@ -3886,27 +3227,17 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
-
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
+minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-minimist@~0.0.1, minimist@~0.0.8:
+minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
 
 "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -3914,45 +3245,13 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@~0.3.3:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
-
 mobx@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.3.0.tgz#1bc1dd7e78547065af04b49bdb7f2098cada47aa"
 
-module-deps@^4.0.8:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-4.1.1.tgz#23215833f1da13fd606ccb8087b44852dcb821fd"
-  dependencies:
-    JSONStream "^1.0.3"
-    browser-resolve "^1.7.0"
-    cached-path-relative "^1.0.0"
-    concat-stream "~1.5.0"
-    defined "^1.0.0"
-    detective "^4.0.0"
-    duplexer2 "^0.1.2"
-    inherits "^2.0.1"
-    parents "^1.0.0"
-    readable-stream "^2.0.2"
-    resolve "^1.1.3"
-    stream-combiner2 "^1.1.1"
-    subarg "^1.0.0"
-    through2 "^2.0.0"
-    xtend "^4.0.0"
-
-monotonic-timestamp@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/monotonic-timestamp/-/monotonic-timestamp-0.0.8.tgz#67987d02a41c15f568b6c0a05885989dd2402ba0"
-
 mri@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"
-
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
 ms@2.0.0:
   version "2.0.0"
@@ -4041,6 +3340,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -4098,18 +3401,6 @@ nth-check@~1.0.1:
   dependencies:
     boolbase "~1.0.0"
 
-nugget@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
-  dependencies:
-    debug "^2.1.3"
-    minimist "^1.1.0"
-    pretty-bytes "^1.0.2"
-    progress-stream "^1.1.0"
-    request "^2.45.0"
-    single-line-log "^1.1.2"
-    throttleit "0.0.2"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -4130,10 +3421,6 @@ object-inspect@^1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
 
-object-inspect@~1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
-
 object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
@@ -4141,10 +3428,6 @@ object-is@^1.0.1:
 object-keys@^1.0.10, object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
-object-keys@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
 object.assign@^4.0.4:
   version "4.0.4"
@@ -4238,7 +3521,7 @@ opn@^4.0.0:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
 
-optimist@^0.6.1, optimist@~0.6.1:
+optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
@@ -4264,14 +3547,6 @@ ora@^0.2.3:
     cli-cursor "^1.0.2"
     cli-spinners "^0.1.2"
     object-assign "^4.0.1"
-
-ordered-emitter@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ordered-emitter/-/ordered-emitter-0.1.1.tgz#aa20bdafbdcc1631834a350f68b4ef8eb34eed7b"
-
-os-browserify@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.1.2.tgz#49ca0293e0b19590a5f5de10c7f265a617d8fe54"
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
@@ -4329,26 +3604,6 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
-pako@~0.2.0:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
-
-parents@^1.0.0, parents@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parents/-/parents-1.0.1.tgz#fedd4d2bf193a77745fe71e371d73c3307d9c751"
-  dependencies:
-    path-platform "~0.11.15"
-
-parse-asn1@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.0.tgz#37c4f9b7ed3ab65c74817b5f2480937fbf97c712"
-  dependencies:
-    asn1.js "^4.0.0"
-    browserify-aes "^1.0.0"
-    create-hash "^1.1.0"
-    evp_bytestokey "^1.0.0"
-    pbkdf2 "^3.0.3"
-
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -4364,10 +3619,6 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse-ms@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
-
 parse5@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.2.tgz#05eff57f0ef4577fb144a79f8b9a967a6cc44510"
@@ -4380,11 +3631,7 @@ parse5@^3.0.2:
   dependencies:
     "@types/node" "*"
 
-path-browserify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
-
-path-exists@^2.0.0, path-exists@^2.1.0:
+path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   dependencies:
@@ -4410,10 +3657,6 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
-path-platform@~0.11.15:
-  version "0.11.15"
-  resolved "https://registry.yarnpkg.com/path-platform/-/path-platform-0.11.15.tgz#e864217f74c36850f0852b78dc7bf7d4a5721bf2"
-
 path-type@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -4428,20 +3671,6 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-pbkdf2@^3.0.3:
-  version "3.0.12"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.12.tgz#be36785c5067ea48d806ff923288c5f750b6b8a2"
-  dependencies:
-    create-hash "^1.1.2"
-    create-hmac "^1.1.4"
-    ripemd160 "^2.0.1"
-    safe-buffer "^5.0.1"
-    sha.js "^2.4.8"
-
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -4449,12 +3678,6 @@ performance-now@^0.2.0:
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-
-phantomjs-stream@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/phantomjs-stream/-/phantomjs-stream-1.1.1.tgz#5650f42028c09e846bc463b82bf4cafc43a3ba2b"
-  dependencies:
-    stream-read "^1.1.2"
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -4478,16 +3701,6 @@ pkginfo@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.0.tgz#349dbb7ffd38081fcadc0853df687f0c7744cd65"
 
-plist@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/plist/-/plist-0.2.1.tgz#f3a3de07885d773e66d8a96782f1bec28cf2b2d0"
-  dependencies:
-    sax "0.1.x"
-
-plur@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/plur/-/plur-1.0.0.tgz#db85c6814f5e5e5a3b49efc28d604fec62975156"
-
 pn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -4508,13 +3721,6 @@ prettier@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.2.tgz#81371e64018aafc69cf1031956c70e029339f54e"
 
-pretty-bytes@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"
-  dependencies:
-    get-stdin "^4.0.1"
-    meow "^3.1.0"
-
 pretty-format@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
@@ -4529,14 +3735,6 @@ pretty-format@^22.0.5:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-ms@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-2.1.0.tgz#4257c256df3fb0b451d6affaab021884126981dc"
-  dependencies:
-    is-finite "^1.0.1"
-    parse-ms "^1.0.0"
-    plur "^1.0.0"
-
 private@^0.1.6, private@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -4544,17 +3742,6 @@ private@^0.1.6, private@^0.1.7:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-
-process@~0.11.0:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-
-progress-stream@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/progress-stream/-/progress-stream-1.2.0.tgz#2cd3cfea33ba3a89c9c121ec3347abe9ab125f77"
-  dependencies:
-    speedometer "~0.1.2"
-    through2 "~0.2.3"
 
 promise@^7.1.1:
   version "7.3.1"
@@ -4574,21 +3761,7 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-public-encrypt@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.0.tgz#39f699f3a46560dd5ebacbca693caf7c65c18cc6"
-  dependencies:
-    bn.js "^4.1.0"
-    browserify-rsa "^4.0.0"
-    create-hash "^1.1.0"
-    parse-asn1 "^5.0.0"
-    randombytes "^2.0.1"
-
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-
-punycode@^1.3.2, punycode@^1.4.1:
+punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
@@ -4603,14 +3776,6 @@ qs@~6.4.0:
 qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-
-querystring-es3@~0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
 raf@^3.4.0:
   version "3.4.0"
@@ -4636,12 +3801,6 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-randombytes@^2.0.0, randombytes@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.5.tgz#dc009a246b8d09a177b4b7a0ae77bc570f4b1b79"
-  dependencies:
-    safe-buffer "^5.1.0"
-
 range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -4655,7 +3814,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.2, rc@^1.1.6:
+rc@^1.0.1, rc@^1.1.6:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
   dependencies:
@@ -4672,10 +3831,6 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-re-emitter@^1.0.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/re-emitter/-/re-emitter-1.1.3.tgz#fa9e319ffdeeeb35b27296ef0f3d374dac2f52a7"
 
 react-dom@^16.0.0:
   version "16.0.0"
@@ -4702,12 +3857,6 @@ react@^16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-read-only-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/read-only-stream/-/read-only-stream-2.0.0.tgz#2724fd6a8113d73764ac288d4386270c1dbf17f0"
-  dependencies:
-    readable-stream "^2.0.2"
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -4723,16 +3872,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@>=1.1.13-1 <1.2.0-0", readable-stream@^1.0.27-1, readable-stream@^1.1.13-1, readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -4743,32 +3883,6 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
-
-readable-stream@~1.0.17, readable-stream@~1.0.27-1:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@~2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-wrap@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/readable-wrap/-/readable-wrap-1.0.0.tgz#3b5a211c631e12303a54991c806c17e7ae206bff"
-  dependencies:
-    readable-stream "^1.1.13-1"
 
 realpath-native@^1.0.0:
   version "1.0.0"
@@ -4873,7 +3987,7 @@ request-promise-native@^1.0.3:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2.81.0, request@^2.45.0:
+request@2.81.0:
   version "2.81.0"
   resolved "https://registry.npmjs.org/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -4947,15 +4061,9 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.6, resolve@^1.4.0, resolve@~1.4.0:
+resolve@^1.1.6, resolve@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
-  dependencies:
-    path-parse "^1.0.5"
-
-resolve@^1.1.4:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
     path-parse "^1.0.5"
 
@@ -4965,12 +4073,6 @@ restore-cursor@^1.0.1:
   dependencies:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
-
-resumer@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
-  dependencies:
-    through "~2.3.4"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -4987,19 +4089,6 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
-
-rimraf@^2.2.8:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
-  dependencies:
-    glob "^7.0.5"
-
-ripemd160@^2.0.0, ripemd160@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
-  dependencies:
-    hash-base "^2.0.0"
-    inherits "^2.0.1"
 
 rollup-plugin-alias@^1.3.0:
   version "1.3.1"
@@ -5079,7 +4168,7 @@ rxjs@^5.0.0-beta.11:
   dependencies:
     symbol-observable "^1.0.1"
 
-safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -5096,10 +4185,6 @@ sane@^2.0.0:
     watch "~0.18.0"
   optionalDependencies:
     fsevents "^1.1.1"
-
-sax@0.1.x:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-0.1.5.tgz#d1829a6120fa01665eb4dbff6c43f29fd6d61471"
 
 sax@^1.2.1:
   version "1.2.4"
@@ -5158,10 +4243,6 @@ serve@^6.1.0:
     send "0.15.4"
     update-notifier "2.2.0"
 
-server-destroy@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
-
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -5174,19 +4255,6 @@ setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
-sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
-  version "2.4.8"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
-  dependencies:
-    inherits "^2.0.1"
-
-shasum@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/shasum/-/shasum-1.0.2.tgz#e7012310d8f417f4deb5712150e5678b87ae565f"
-  dependencies:
-    json-stable-stringify "~0.0.0"
-    sha.js "~2.4.4"
-
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -5197,15 +4265,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shell-quote@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
-  dependencies:
-    array-filter "~0.0.0"
-    array-map "~0.0.0"
-    array-reduce "~0.0.0"
-    jsonify "~0.0.0"
-
 shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -5213,12 +4272,6 @@ shellwords@^0.1.0:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-
-single-line-log@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/single-line-log/-/single-line-log-1.1.2.tgz#c2f83f273a3e1a16edb0995661da0ed5ef033364"
-  dependencies:
-    string-width "^1.0.1"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -5240,7 +4293,7 @@ sntp@2.x.x:
   dependencies:
     hoek "4.x.x"
 
-source-map-support@^0.4.0, source-map-support@^0.4.15:
+source-map-support@^0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
   dependencies:
@@ -5262,7 +4315,7 @@ source-map@^0.5.3, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -5283,28 +4336,6 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
-
-speedometer@~0.1.2:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
-
-split@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/split/-/split-1.0.0.tgz#c4395ce683abcd254bc28fe1dabb6e5c27dcffae"
-  dependencies:
-    through "2"
-
-split@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.1.2.tgz#f0710744c453d551fc7143ead983da6014e336cc"
-  dependencies:
-    through "1"
-
-split@~0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
-  dependencies:
-    through "2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -5339,54 +4370,6 @@ staged-git-files@0.0.4:
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-
-stream-browserify@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
-  dependencies:
-    inherits "~2.0.1"
-    readable-stream "^2.0.2"
-
-stream-combiner2@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
-  dependencies:
-    duplexer2 "~0.1.0"
-    readable-stream "^2.0.2"
-
-stream-http@^2.0.0:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
-  dependencies:
-    builtin-status-codes "^3.0.0"
-    inherits "^2.0.1"
-    readable-stream "^2.2.6"
-    to-arraybuffer "^1.0.0"
-    xtend "^4.0.0"
-
-stream-read@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/stream-read/-/stream-read-1.1.2.tgz#3137110d7aa80ba54e4b829c4cd33ca106b9564d"
-  dependencies:
-    dezalgo "^1.0.1"
-
-stream-splicer@^1.2.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/stream-splicer/-/stream-splicer-1.3.2.tgz#3c0441be15b9bf4e226275e6dc83964745546661"
-  dependencies:
-    indexof "0.0.1"
-    inherits "^2.0.1"
-    isarray "~0.0.1"
-    readable-stream "^1.1.13-1"
-    readable-wrap "^1.0.0"
-    through2 "^1.0.0"
-
-stream-splicer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/stream-splicer/-/stream-splicer-2.0.0.tgz#1b63be438a133e4b671cc1935197600175910d83"
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.0.2"
 
 stream-to-observable@^0.1.0:
   version "0.1.0"
@@ -5427,19 +4410,7 @@ string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string.prototype.trim@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.0"
-    function-bind "^1.0.2"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-
-string_decoder@~1.0.0, string_decoder@~1.0.3:
+string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
@@ -5489,22 +4460,13 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
-subarg@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
-  dependencies:
-    minimist "^1.1.0"
-
-sumchecker@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-1.3.1.tgz#79bb3b4456dd04f18ebdbc0d703a1d1daec5105d"
-  dependencies:
-    debug "^2.2.0"
-    es6-promise "^4.0.5"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -5529,75 +4491,6 @@ symbol-observable@^1.0.1:
 symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
-
-syntax-error@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.3.0.tgz#1ed9266c4d40be75dc55bf9bb1cb77062bb96ca1"
-  dependencies:
-    acorn "^4.0.3"
-
-tap-finished@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/tap-finished/-/tap-finished-0.0.0.tgz#4c3e7ccbea7fa0a28fadfb1c03088e8be9a62e81"
-  dependencies:
-    tap-parser "~0.0.2"
-    through "~2.1.0"
-
-tap-out@^1.4.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/tap-out/-/tap-out-1.4.2.tgz#c907ec1bf9405111d088263e92f5608b88cbb37a"
-  dependencies:
-    re-emitter "^1.0.0"
-    readable-stream "^2.0.0"
-    split "^1.0.0"
-    trim "0.0.1"
-
-tap-parser@~0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-0.0.2.tgz#f5f020f36a90596d17c1f85c1d43ac81e2f46292"
-  dependencies:
-    split "~0.1.2"
-
-tap-spec@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/tap-spec/-/tap-spec-4.1.1.tgz#e2e9f26f5208232b1f562288c97624d58a88f05a"
-  dependencies:
-    chalk "^1.0.0"
-    duplexer "^0.1.1"
-    figures "^1.4.0"
-    lodash "^3.6.0"
-    pretty-ms "^2.1.0"
-    repeat-string "^1.5.2"
-    tap-out "^1.4.1"
-    through2 "^2.0.0"
-
-tape-run@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tape-run/-/tape-run-2.1.0.tgz#b7884ac2426fc67089bb1edfb5e5bfc961f2b186"
-  dependencies:
-    browser-run "^3.0.2"
-    optimist "~0.6.1"
-    tap-finished "0.0.0"
-    through "~2.3.4"
-    throughout "0.0.0"
-
-tape@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.8.0.tgz#f6a9fec41cc50a1de50fa33603ab580991f6068e"
-  dependencies:
-    deep-equal "~1.0.1"
-    defined "~1.0.0"
-    for-each "~0.3.2"
-    function-bind "~1.1.0"
-    glob "~7.1.2"
-    has "~1.0.1"
-    inherits "~2.0.3"
-    minimist "~1.2.0"
-    object-inspect "~1.3.0"
-    resolve "~1.4.0"
-    resumer "~0.0.0"
-    string.prototype.trim "~1.1.2"
-    through "~2.3.8"
 
 tar-pack@^3.4.0:
   version "3.4.1"
@@ -5657,74 +4550,13 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
-throttleit@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
-
-through2@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-1.1.1.tgz#0847cbc4449f3405574dbdccd9bb841b83ac3545"
-  dependencies:
-    readable-stream ">=1.1.13-1 <1.2.0-0"
-    xtend ">=4.0.0 <4.1.0-0"
-
-through2@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
-  dependencies:
-    readable-stream "^2.1.5"
-    xtend "~4.0.1"
-
-through2@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-0.2.3.tgz#eb3284da4ea311b6cc8ace3653748a52abf25a3f"
-  dependencies:
-    readable-stream "~1.1.9"
-    xtend "~2.1.1"
-
-through2@~0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
-  dependencies:
-    readable-stream "~1.0.17"
-    xtend "~2.1.1"
-
-through@1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/through/-/through-1.1.2.tgz#344a5425a3773314ca7e0eb6512fbafaf76c0bfe"
-
-through@2, "through@>=2.2.7 <3", through@X.X.X, through@^2.3.8, through@~2.3.4, through@~2.3.8:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-through@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.1.0.tgz#ebcae48745ffda088ad6b8a2fe20ef3ce8ee1bcd"
-
-throughout@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/throughout/-/throughout-0.0.0.tgz#da935527231a7944daa60d3ad47a32429af1a8c1"
-  dependencies:
-    duplexer "~0.0.2"
-    through "~2.3.4"
-
 timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
-timers-browserify@^1.0.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-1.4.2.tgz#c9c58b575be8407375cb5e2462dacee74359f41d"
-  dependencies:
-    process "~0.11.0"
-
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
-
-to-arraybuffer@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -5756,25 +4588,6 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-
-trumpet@^1.7.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/trumpet/-/trumpet-1.7.2.tgz#b02c69e465d171f55e44924bf9b5bdd20974c830"
-  dependencies:
-    duplexer2 "~0.0.2"
-    html-select "^2.3.5"
-    html-tokenize "^1.1.1"
-    inherits "^2.0.0"
-    readable-stream "^1.0.27-1"
-    through2 "^1.0.0"
-
-tty-browserify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
-
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -5790,10 +4603,6 @@ type-check@~0.3.2:
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
-
-typedarray@^0.0.6, typedarray@~0.0.5:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 typescript@2.6:
   version "2.6.1"
@@ -5826,10 +4635,6 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-
-umd@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.1.tgz#8ae556e11011f63c2596708a8837259f01b3d60e"
 
 underscore@~1.4.4:
   version "1.4.4"
@@ -5866,22 +4671,11 @@ update-notifier@2.2.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-url-join@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.2.tgz#c072756967ad24b8b59e5741551caac78f50b8b7"
-
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
-
-url@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -5893,12 +4687,6 @@ util.promisify@^1.0.0:
   dependencies:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
-
-util@0.10.3, util@~0.10.1:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  dependencies:
-    inherits "2.0.1"
 
 uuid@^2.0.1:
   version "2.0.3"
@@ -5928,12 +4716,6 @@ verror@1.3.6:
 vlq@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
-
-vm-browserify@~0.0.1:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
-  dependencies:
-    indexof "0.0.1"
 
 walker@~1.0.5:
   version "1.0.7"
@@ -6031,26 +4813,9 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
-xhr-write-stream@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/xhr-write-stream/-/xhr-write-stream-0.1.2.tgz#e357848e0d039b411fdd5b3bf81be47ee5ce26aa"
-  dependencies:
-    concat-stream "~0.1.0"
-    ordered-emitter "~0.1.0"
-
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
-
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-xtend@~2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
-  dependencies:
-    object-keys "~0.4.0"
 
 y18n@^3.2.1:
   version "3.2.1"
@@ -6091,9 +4856,3 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-
-yauzl@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
-  dependencies:
-    fd-slicer "~1.0.1"


### PR DESCRIPTION
For some reason `husky` wasn't installed so `precommit` hook for running Prettier was never used. That leads to PR like #403 which also includes reformatting so it's harder to review.

I've run Prettier manually to fix formatting in all files. I've also added `.prettierignore` for `package.json` which is also formatted differently by Yarn on any install.

Lastly there is no need to repeat Prettier rules in for `lint-staged`, the `.prettierrc` file is respected correctly.