### PR TITLE
Smart inject typing

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,10 @@
 /**
+ *  Diff & Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
+ */
+type Diff<T extends string, U extends string> = ({[P in T]: P } & {[P in U]: never } & { [x: string]: never })[T];
+type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
+
+/**
  * Turns a React component or stateless render function into a reactive component.
  */
 import React = require("react")
@@ -40,9 +46,12 @@ export type IWrappedComponent<P> = {
 export function inject(
     ...stores: string[]
 ): <T extends IReactComponent>(target: T) => T & IWrappedComponent<T>
-export function inject<S, P, I, C>(
+export function inject<S, P extends I, I>(
+    fn: IStoresToProps<S, P, I>
+): <T extends IReactComponent>(target: T) => IReactComponent<Omit<P, keyof I>> & IWrappedComponent<T>
+export function inject<S, P extends I, I, C>(
     fn: IStoresToProps<S, P, I, C>
-): <T extends IReactComponent>(target: T) => T & IWrappedComponent<T>
+): <T extends IReactComponent>(target: T) => IReactComponent<Omit<P, keyof I>> & IWrappedComponent<T>
 
 // Ideal implemetnation:
 // export function inject


### PR DESCRIPTION
Fixes #256.

```ts
interface Store {
  profile: {
    name: string;
  };
}

interface InjectProps {
  name: string;
}
  
interface OwnProps {
  age: number;
}

type Props = InjectProps & OwnProps;

// way 1
inject<Stores, Props, InjectedProps>((stores) => ({
  name: stores.profile.name,
})(ProfileComponent);

// way 2
inject((stores: Stores, props: Props): InjectProps => ({
  name: stores.profile.name,
})(ProfileComponent);

// way 3 (if Props is same as InjectProps)
inject((stores: Stores): InjectProps => ({
  name: stores.profile.name,
})(ProfileComponent);
```

In this case, it needs only the props which are not provided by `inject` function to render injected component.

But, there is a problem that it doesn't support `decorator`.