### PR TITLE
Optimize reactive props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /test/browser/test_bundle.js
 /.source.*
 yarn-error.log
+/package-lock.json

--- a/src/observer.js
+++ b/src/observer.js
@@ -110,8 +110,6 @@ function is(x, y) {
     }
 }
 
-const skipRenderKey = Symbol("skipRender")
-
 /**
  * ReactiveMixin
  */

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,6 +1,6 @@
 import React, { Component, PureComponent } from "react"
 import hoistStatics from "hoist-non-react-statics"
-import { createAtom, Reaction, _allowStateChanges } from "mobx"
+import { createAtom, Reaction, _allowStateChanges, runInAction } from "mobx"
 import { findDOMNode as baseFindDOMNode } from "react-dom"
 import EventEmitter from "./utils/EventEmitter"
 import inject from "./inject"
@@ -71,14 +71,14 @@ function patch(target, funcName, runMixinFirst = false) {
     const f = !base
         ? mixinFunc
         : runMixinFirst === true
-          ? function() {
-                mixinFunc.apply(this, arguments)
-                base.apply(this, arguments)
-            }
-          : function() {
-                base.apply(this, arguments)
-                mixinFunc.apply(this, arguments)
-            }
+            ? function() {
+                  mixinFunc.apply(this, arguments)
+                  base.apply(this, arguments)
+              }
+            : function() {
+                  base.apply(this, arguments)
+                  mixinFunc.apply(this, arguments)
+              }
 
     // MWE: ideally we freeze here to protect against accidental overwrites in component instances, see #195
     // ...but that breaks react-hot-loader, see #231...
@@ -122,8 +122,8 @@ function makeComponentReactive(render) {
         const individualValues = {}
 
         /**
-             * In-place convert properties to getter+setter
-             */
+         * In-place convert properties to getter+setter
+         */
         function convertStorageToReactive(storage) {
             if (null == storage) {
                 return storage
@@ -137,7 +137,7 @@ function makeComponentReactive(render) {
             }
             Object.keys(storage).forEach(function(key) {
                 if (!(key in individualAtoms)) {
-                    individualAtoms[key] = new Atom("this." + propName + "." + key)
+                    individualAtoms[key] = createAtom("this." + propName + "." + key)
                 }
                 const currentKeyValue = storage[key]
                 delete storage[key]
@@ -161,8 +161,8 @@ function makeComponentReactive(render) {
         }
 
         /**
-             * In-place convert getter+setter to plain property
-             */
+         * In-place convert getter+setter to plain property
+         */
         function convertStorageToStatic(storage) {
             if (null == storage) {
                 return

--- a/test/issue21.test.js
+++ b/test/issue21.test.js
@@ -378,11 +378,24 @@ test("verify change of non-accessed prop do not trigger reaction", async () => {
     expect(computedCalls).toEqual(["prop2: 2"])
     computedCalls.length = 0
 
+    // prop2 is untouched, prop1 changes from 2 to 1
+    renderFnStore.set(function() {
+        return <Component prop1={1} prop2={2} />
+    })
+    expect(computedCalls).toEqual(["prop1: 1"])
+    computedCalls.length = 0
+
+    // nothing changed - no recalc
+    renderFnStore.set(function() {
+        return <Component prop1={1} prop2={2} />
+    })
+    expect(computedCalls).toEqual([])
+    computedCalls.length = 0
+
     // prop1 disappear, prop2 is untouched
     renderFnStore.set(function() {
         return <Component prop2={2} />
     })
-    // if prop disappears, then all props-related computeds should be recalculated
     expect(computedCalls).toEqual(["prop1: undefined", "prop2: 2"])
     computedCalls.length = 0
 
@@ -390,8 +403,28 @@ test("verify change of non-accessed prop do not trigger reaction", async () => {
     renderFnStore.set(function() {
         return <Component prop1={2} />
     })
-    // if prop disappears, then all props-related computeds should be recalculated
     expect(computedCalls).toEqual(["prop1: 2", "prop2: undefined"])
+    computedCalls.length = 0
+
+    // remove prop1 should trigger both computed for now. It would be good to not to recalc prop2
+    renderFnStore.set(function() {
+        return <Component />
+    })
+    expect(computedCalls).toEqual(["prop1: undefined", "prop2: undefined"])
+    computedCalls.length = 0
+
+    // and correct catch prop appears after been disappeared
+    renderFnStore.set(function() {
+        return <Component prop1={2} />
+    })
+    expect(computedCalls).toEqual(["prop1: 2", "prop2: undefined"])
+    computedCalls.length = 0
+
+    // swap again - all recalculated
+    renderFnStore.set(function() {
+        return <Component prop2={2} />
+    })
+    expect(computedCalls).toEqual(["prop1: undefined", "prop2: 2"])
     computedCalls.length = 0
 })
 

--- a/test/issue21.test.js
+++ b/test/issue21.test.js
@@ -360,7 +360,7 @@ test("verify change of non-accessed prop do not trigger reaction", async () => {
     renderFnStore.set(function() {
         return <Component prop1={2} />
     })
-    expect(computedCalls).toEqual(["prop1: 1"])
+    expect(computedCalls).toEqual(["prop1: 2"])
     computedCalls.length = 0
 
     // prop1 is untouched, prop2 appears
@@ -384,6 +384,14 @@ test("verify change of non-accessed prop do not trigger reaction", async () => {
     })
     // if prop disappears, then all props-related computeds should be recalculated
     expect(computedCalls).toEqual(["prop1: undefined", "prop2: 2"])
+    computedCalls.length = 0
+
+    // If we replace prop2 to prop1, both computeds should be recalculated
+    renderFnStore.set(function() {
+        return <Component prop1={2} />
+    })
+    // if prop disappears, then all props-related computeds should be recalculated
+    expect(computedCalls).toEqual(["prop1: 2", "prop2: undefined"])
     computedCalls.length = 0
 })
 


### PR DESCRIPTION
Particular fix for #380 #347

Achieve granular observale state/props

Technique:
Instead of having only 1 atom for whole props/state, we have N atoms for each property/state element, and extra one which track keyset change

When new props object set, we detect key change and report changed for extra atom. Also we instrument props/state object and in-place change properties to getter+setter, which uses atoms and single value storage. Also, previous props/state object should be freezed with it values and de-instrumented from getters and setters, to get lifecycle methods work.

Having extra atom, which detects keys change helps us to detect new props/state element appears.

~~Unfortunatelly, to make in-place instrument with props/state object, I forced to make a extra wrapper for Observer component, which calls to `createElement` and un-freeze it props. This is definetely not good for performance, but `React.createElement` freeze objects :( I think this extra wrapper get this issue back: https://github.com/mobxjs/mobx/issues/405 (and many tests are failed because of this)~~
UPD: solution found

Comments are requested.