### PR TITLE
Fix Component displayed as 'undefined' in mobx-devtools

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -169,6 +169,7 @@ function makeComponentReactive(render) {
         "<component>"
     const rootNodeID =
         (this._reactInternalInstance && this._reactInternalInstance._rootNodeID) ||
+        (this._reactInternalInstance && this._reactInternalInstance._debugID) ||
         (this._reactInternalFiber && this._reactInternalFiber._debugID)
     /**
      * If props are shallowly modified, react will render anyway,


### PR DESCRIPTION
I read through entire codebase and this seems to be spot to fix this little bug. Let me know if I'm way off so I can find the right place to patch this.

