### PR TITLE
fixes HOC displayName for observer and inject

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -34,13 +34,14 @@ const proxiedInjectorProps = {
  * Store Injection
  */
 function createStoreInjector(grabStoresFn, component, injectNames) {
-    let displayName =
-        "inject-" +
-        (component.displayName ||
-            component.name ||
-            (component.constructor && component.constructor.name) ||
-            "Unknown")
-    if (injectNames) displayName += "-with-" + injectNames
+    let displayName
+    const componentName =
+        component.displayName ||
+        component.name ||
+        (component.constructor && component.constructor.name) ||
+        "Component"
+    if (injectNames) displayName = "inject-with-" + injectNames + "(" + componentName + ")"
+    else displayName = "inject(" + componentName + ")"
 
     class Injector extends Component {
         static displayName = displayName

--- a/src/observer.js
+++ b/src/observer.js
@@ -317,7 +317,9 @@ export function observer(arg1, arg2) {
     ) {
         const observerComponent = observer(
             class extends Component {
-                static displayName = componentClass.displayName || componentClass.name
+                static displayName = "observer(" +
+                (componentClass.displayName || componentClass.name) +
+                ")"
                 static contextTypes = componentClass.contextTypes
                 static propTypes = componentClass.propTypes
                 static defaultProps = componentClass.defaultProps
@@ -335,6 +337,10 @@ export function observer(arg1, arg2) {
     }
 
     const target = componentClass.prototype || componentClass
+    if (!componentClass.displayName || !componentClass.displayName.match(/observer\(/)) {
+        componentClass.displayName =
+            "observer(" + (componentClass.displayName || componentClass.name) + ")"
+    }
     mixinLifecycleEvents(target)
     componentClass.isMobXReactObserver = true
     const baseRender = target.render

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -51,6 +51,60 @@ describe("inject based context", () => {
         expect(wrapper.find("div").text()).toEqual("context:42")
     })
 
+    test("wraps displayName of original component", () => {
+        const A = inject("foo")(
+            createClass({
+                displayName: "ComponentA",
+                render() {
+                    return <div>context:{this.props.foo}</div>
+                }
+            })
+        )
+        const B = inject()(
+            createClass({
+                displayName: "ComponentB",
+                render() {
+                    return <div>context:{this.props.foo}</div>
+                }
+            })
+        )
+        const C = inject(() => ({}))(
+            createClass({
+                displayName: "ComponentC",
+                render() {
+                    return <div>context:{this.props.foo}</div>
+                }
+            })
+        )
+        expect(
+            mount(
+                <Provider foo="foo">
+                    <A />
+                </Provider>
+            )
+                .children()
+                .get(0).type.displayName
+        ).toEqual("inject-with-foo(ComponentA)")
+        expect(
+            mount(
+                <Provider>
+                    <B />
+                </Provider>
+            )
+                .children()
+                .get(0).type.displayName
+        ).toEqual("inject(ComponentB)")
+        expect(
+            mount(
+                <Provider>
+                    <C />
+                </Provider>
+            )
+                .children()
+                .get(0).type.displayName
+        ).toEqual("observer(inject(ComponentC))")
+    })
+
     test("overriding stores is supported", () => {
         const C = inject("foo", "bar")(
             observer(
@@ -315,7 +369,7 @@ describe("inject based context", () => {
         mount(<A />)
         expect(msg.length).toBe(2)
         expect(msg[0].split("\n")[0]).toBe(
-            "Warning: Failed prop type: The prop `x` is marked as required in `inject-C-with-foo`, but its value is `undefined`."
+            "Warning: Failed prop type: The prop `x` is marked as required in `inject-with-foo(C)`, but its value is `undefined`."
         )
         expect(msg[1].split("\n")[0]).toBe(
             "Warning: Failed prop type: The prop `a` is marked as required in `C`, but its value is `undefined`."

--- a/test/observer.test.js
+++ b/test/observer.test.js
@@ -14,6 +14,7 @@ import {
     asyncRender
 } from "./"
 import ErrorCatcher from "./ErrorCatcher"
+import { mount } from "enzyme"
 
 /**
  *  some test suite is too tedious
@@ -321,6 +322,20 @@ test("observer component can be injected", () => {
 
     expect(msg.length).toBe(0)
     console.warn = baseWarn
+})
+
+test("correctly wraps display name of child component", () => {
+    const A = observer(
+        createClass({
+            displayName: "ObserverClass",
+            render: () => null
+        })
+    )
+    const B = observer(function StatelessObserver() {
+        return null
+    })
+    expect(mount(<A />).get(0).type.displayName).toEqual("observer(ObserverClass)")
+    expect(mount(<B />).get(0).type.displayName).toEqual("observer(StatelessObserver)")
 })
 
 describe("124 - react to changes in this.props via computed", () => {


### PR DESCRIPTION
Uses the convention for HOC display names as outlined in the React documentation.
https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging

Closes #466 <- See for more details.