### PR TITLE
Don't warn about shouldComponentUpdate from @observer'd superclass

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -352,7 +352,7 @@ function mixinLifecycleEvents(target) {
     })
     if (!target.shouldComponentUpdate) {
         target.shouldComponentUpdate = reactiveMixin.shouldComponentUpdate
-    } else {
+    } else if (target.shouldComponentUpdate !== reactiveMixin.shouldComponentUpdate) {
         // TODO: make throw in next major
         console.warn(
             "Use `shouldComponentUpdate` in an `observer` based component breaks the behavior of `observer` and might lead to unexpected results. Manually implementing `sCU` should not be needed when using mobx-react."


### PR DESCRIPTION
This pull fixes the issue where the following is logged erroneously:

> Use `shouldComponentUpdate` in an `observer` based component breaks the behavior of `observer` and might lead to unexpected results. Manually implementing `sCU` should not be needed when using mobx-react.

This warning is misleading and incorrect if the `shouldComponentUpdate` that is being complained about was added by `@observer` itself. e.g.

```js
@observer
class GenericComponent extends Component {}

@observer // should not complain, but it does
class SpecificComponent extends GenericComponent {}
```