### PR TITLE
Make props & state observable in constructor & componentWillMount

### DIFF
--- a/test/issue21.test.js
+++ b/test/issue21.test.js
@@ -449,3 +449,55 @@ test("lifecycle callbacks called with correct arguments", async () => {
     await asyncReactDOMRender(<Root />, testRoot)
     testRoot.querySelector("#testButton").click()
 })
+
+test("verify props are reactive in componentWillMount and constructor", async () => {
+    const prop1Values = []
+    const prop2Values = []
+    let componentWillMountCallsCount = 0
+    let constructorCallsCount = 0
+
+    const Component = observer(
+        class Component extends React.Component {
+            constructor(props, context) {
+                super(props, context)
+                constructorCallsCount++
+                this.disposer1 = mobx.reaction(
+                    () => this.props.prop1,
+                    prop => prop1Values.push(prop),
+                    {
+                        fireImmediately: true
+                    }
+                )
+            }
+
+            componentWillMount() {
+                componentWillMountCallsCount++
+                this.disposer2 = mobx.reaction(
+                    () => this.props.prop2,
+                    prop => prop2Values.push(prop),
+                    {
+                        fireImmediately: true
+                    }
+                )
+            }
+
+            componentWillUnmount() {
+                this.disposer1()
+                this.disposer2()
+            }
+
+            render() {
+                return <div />
+            }
+        }
+    )
+
+    await asyncReactDOMRender(<Component prop1="1" prop2="4" />, testRoot)
+    await asyncReactDOMRender(<Component prop1="2" prop2="3" />, testRoot)
+    await asyncReactDOMRender(<Component prop1="3" prop2="2" />, testRoot)
+    await asyncReactDOMRender(<Component prop1="4" prop2="1" />, testRoot)
+    expect(constructorCallsCount).toEqual(1)
+    expect(componentWillMountCallsCount).toEqual(1)
+    expect(prop1Values).toEqual(["1", "2", "3", "4"])
+    expect(prop2Values).toEqual(["4", "3", "2", "1"])
+})


### PR DESCRIPTION
Moved instrumentation of state & props to `observer` decorator.
Closes #478