### PR TITLE
Get rid of Symbol at all

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -20,19 +20,16 @@ let warnedAboutObserverInjectDeprecation = false
 export const componentByNodeRegistry = typeof WeakMap !== "undefined" ? new WeakMap() : undefined
 export const renderReporter = new EventEmitter()
 
-function createSymbol(name) {
-    if (global.Symbol) {
-        return Symbol(name)
-    } else {
-        return `$mobxReactProp$${name}${Math.random()}`
-    }
+function getMobxReactHiddenPropName(name) {
+    return `$mobxReactProp$${name}${Math.random()}`
 }
 
-const skipRenderKey = createSymbol("mobxReact-skipRender")
-const isForcingUpdateKey = createSymbol("mobxReact-isForcingUpdate")
+const skipRenderKey = getMobxReactHiddenPropName("skipRender")
+const isForcingUpdateKey = getMobxReactHiddenPropName("sForcingUpdate")
 
 /**
  * Helper to set `prop` to `this` as non-enumerable (hidden prop)
+ * @param target
  * @param prop
  * @param value
  */
@@ -275,8 +272,8 @@ const reactiveMixin = {
 }
 
 function makeObservableProp(target, propName) {
-    const valueHolderKey = createSymbol(propName + " value holder")
-    const atomHolderKey = createSymbol(propName + " atom holder")
+    const valueHolderKey = getMobxReactHiddenPropName(propName + " value holder")
+    const atomHolderKey = getMobxReactHiddenPropName(propName + " atom holder")
     function getAtom() {
         if (!this[atomHolderKey]) {
             setHiddenProp(this, atomHolderKey, createAtom("reactive " + propName))


### PR DESCRIPTION
Motivation:

mobx itself has hidden properties and don't use Symbols at all. I don't think that we need symbol here.