### PR TITLE
fix: React-Hot-Loader compatibility

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -20,11 +20,20 @@ let warnedAboutObserverInjectDeprecation = false
 export const componentByNodeRegistry = typeof WeakMap !== "undefined" ? new WeakMap() : undefined
 export const renderReporter = new EventEmitter()
 
-function createSymbol(name) {
+const createdSymbols = {}
+
+function createRealSymbol(name) {
     if (typeof Symbol === "function") {
         return Symbol(name)
     }
     return `$mobxReactProp$${name}${Math.random()}`
+}
+
+function createSymbol(name) {
+    if (!createdSymbols[name]) {
+        createdSymbols[name] = createRealSymbol(name)
+    }
+    return createdSymbols[name]
 }
 
 const skipRenderKey = createSymbol("skipRender")


### PR DESCRIPTION
Source issue: #500.

Just changing `createSymbol` to behave like pure function and return the same result for the same arguments.
As a result - after hot class update `.state` and `.props` refers the same underlaying objects.
Before - RHL did not work due to runtime error, as long `.state` was `undefined` for a while.