### PR TITLE
Fix windows compilation + remove nscript due to fibers dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "jest && npm run test:ts",
     "test:ts": "tsc -p test/ts",
     "test:travis": "npm run build && jest && npm run test:ts",
-    "build": "node build-rollup.js && cp src/index.d.ts index.d.ts && cp src/index.d.ts native.d.ts && cp src/index.d.ts custom.d.ts",
+    "build": "node build-rollup.js && shx cp src/index.d.ts index.d.ts && shx cp src/index.d.ts native.d.ts && shx cp src/index.d.ts custom.d.ts",
     "precommit": "lint-staged",
     "watch": "jest --watch"
   },
@@ -52,7 +52,6 @@
     "lint-staged": "^7.0.5",
     "lodash": "^4.17.4",
     "mobx": "5.0.0",
-    "nscript": "^0.1.10",
     "opn-cli": "^3.1.0",
     "prettier": "^1.7.2",
     "prop-types": "^15.6.0",
@@ -69,6 +68,8 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-uglify": "^2.0.1",
     "serve": "^7.0.0",
+    "shelljs": "^0.8.2",
+    "shx": "^0.3.2",
     "typescript": "2.6"
   },
   "dependencies": {

--- a/publish.js
+++ b/publish.js
@@ -1,38 +1,86 @@
-#!./node_modules/.bin/nscript
-/* To run this script, nscript is needed: [sudo] npm install -g nscript
 /* Publish.js, publish a new version of the npm package as found in the current directory */
-module.exports = function(shell, npm, git) {
-    var pkg = JSON.parse(shell.read("package.json"))
+/* Run this file from the root of the repository */
 
-    npm("run", "build")
+const shell = require("shelljs")
+const fs = require("fs")
+const readline = require("readline")
+
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+})
+
+function run(command, options) {
+    const continueOnErrors = options && options.continueOnErrors
+    const ret = shell.exec(command, options)
+    if (!continueOnErrors && ret.code !== 0) {
+        shell.exit(1)
+    }
+    return ret
+}
+
+function exit(code, msg) {
+    console.error(msg)
+    shell.exit(code)
+}
+
+async function prompt(question, defaultValue) {
+    return new Promise(resolve => {
+        rl.question(`${question} [${defaultValue}]: `, answer => {
+            answer = answer && answer.trim()
+            resolve(answer ? answer : defaultValue)
+        })
+    })
+}
+
+async function main() {
+    // build
+    run("npm run small-build")
+
+    const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"))
 
     // Bump version number
-    var nrs = pkg.version.split(".")
+    let nrs = pkg.version.split(".")
     nrs[2] = 1 + parseInt(nrs[2], 10)
-    var version = (pkg.version = shell.prompt(
+    const version = (pkg.version = await prompt(
         "Please specify the new package version of '" + pkg.name + "' (Ctrl^C to abort)",
         nrs.join(".")
     ))
-    if (!version.match(/^\d+\.\d+\.\d+$/)) shell.exit(1, "Invalid semantic version: " + version)
+    if (!version.match(/^\d+\.\d+\.\d+$/)) {
+        exit(1, "Invalid semantic version: " + version)
+    }
 
-    // Check registery data
-    if (npm.silent().test("info", pkg.name)) {
+    // Check registry data
+    const npmInfoRet = run(`npm info ${pkg.name} --json`, {
+        continueOnErrors: true,
+        silent: true
+    })
+    if (npmInfoRet.code === 0) {
         //package is registered in npm?
-        var publishedPackageInfo = JSON.parse(npm.get("info", pkg.name, "--json"))
+        var publishedPackageInfo = JSON.parse(npmInfoRet.stdout)
         if (
             publishedPackageInfo.versions == version ||
-            publishedPackageInfo.versions.indexOf(version) != -1
-        )
-            shell.exit(2, "Version " + pkg.version + " is already published to npm")
+            publishedPackageInfo.versions.includes(version)
+        ) {
+            exit(2, "Version " + pkg.version + " is already published to npm")
+        }
 
-        shell.write("package.json", JSON.stringify(pkg, null, 2))
+        fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2), "utf8")
 
-        npm("publish")
-        git("commit", "-am", "Published version " + version)
-        git("tag", version)
+        // Finally, commit and publish!
+        run("npm publish")
+        run(`git commit -am "Published version ${version}"`)
+        run(`git tag ${version}`)
 
-        git("push")
-        git("push", "--tags")
+        run("git push")
+        run("git push --tags")
         console.log("Published!")
-    } else shell.exit(1, pkg.name + " is not an existing npm package")
+        exit(0)
+    } else {
+        exit(1, pkg.name + " is not an existing npm package")
+    }
 }
+
+main().catch(e => {
+    throw e
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,13 +1037,6 @@ boxen@^1.1.0:
     term-size "^0.1.0"
     widest-line "^1.0.0"
 
-brace-expansion@^1.0.0:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1280,7 +1273,7 @@ colors@0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
-colors@^1.0.3, colors@^1.1.2:
+colors@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -1293,12 +1286,6 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
 commander@^2.14.1, commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
-
-commander@^2.6.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.10.0.tgz#e1f5d3245de246d1a5ca04702fa1ad1bd7e405fe"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
 
 commander@~2.11.0:
   version "2.11.0"
@@ -1681,6 +1668,10 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es6-object-assign@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -1903,10 +1894,6 @@ fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fibers@^1.0.2:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/fibers/-/fibers-1.0.15.tgz#22f039c8f18b856190fbbe4decf056154c1eae9c"
-
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2094,14 +2081,16 @@ glob-slasher@1.0.1:
     lodash.isobject "^2.4.1"
     toxic "^1.0.0"
 
-glob@^4.3.2:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
+glob@^7.0.0:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
+    fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^2.0.1"
+    minimatch "^3.0.4"
     once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
@@ -2125,10 +2114,6 @@ globals@^9.18.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2233,10 +2218,6 @@ hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
-home-dir@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/home-dir/-/home-dir-0.2.0.tgz#765cac335384b51f31fd0448e4cdd8066e1e2c8f"
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -2338,6 +2319,10 @@ inherits@2, inherits@^2.0.1, inherits@~2.0.3:
 ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+interpret@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -3540,12 +3525,6 @@ minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^2.0.1:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
-  dependencies:
-    brace-expansion "^1.0.0"
-
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -3758,16 +3737,6 @@ npmlog@^4.0.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
-
-nscript@^0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/nscript/-/nscript-0.1.10.tgz#25b5925f84a62769b07c1fe6372d7c7cfad4e904"
-  dependencies:
-    colors "^1.0.3"
-    commander "^2.6.0"
-    fibers "^1.0.2"
-    glob "^4.3.2"
-    home-dir "^0.2.0"
 
 nth-check@~1.0.1:
   version "1.0.1"
@@ -4265,6 +4234,12 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -4656,9 +4631,25 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shelljs@^0.8.1, shelljs@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.2.tgz#345b7df7763f4c2340d584abb532c5f752ca9e35"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+
+shx@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
+  dependencies:
+    es6-object-assign "^1.0.3"
+    minimist "^1.2.0"
+    shelljs "^0.8.1"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Basically the same that was done for mobx in https://github.com/mobxjs/mobx/pull/1735

This PR:

* removes nscript due to a dependency with fibers, a native node module that was kinda hard to compile (and actually impossible with new node versions due to compilation errors)
* fixes the publish build script so it doesn't use such dependency and uses shelljs instead
* fixes publish and build script so they work in windows as well

I think this should help new contributors get up and running faster