### PR TITLE
Replace recommendation of deprecated lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ class TodoView extends React.Component {
 ```
 
 *   `componentWillReact` doesn't take arguments
-*   `componentWillReact` won't fire before the initial render (use `componentWillMount` instead)
+*   `componentWillReact` won't fire before the initial render (use use `componentDidMount` or `constructor` instead)
 
 ### `PropTypes`
 


### PR DESCRIPTION
#447
As mentioned, React discourages using `componentWillMount`. I think it is better not to recommend `componentWillMount` to replace `componentWillReact` even if we using a version lower than `React 16.3`.
I did not write `getDerivedStateFromProps` because it is only for new version users.