### PR TITLE
fixing inheritance patching

### DIFF
--- a/src/disposeOnUnmount.js
+++ b/src/disposeOnUnmount.js
@@ -6,7 +6,7 @@ const storeKey = newSymbol("disposeOnUnmount")
 function runDisposersOnWillUnmount() {
     if (!this[storeKey]) {
         // when disposeOnUnmount is only set to some instances of a component it will still patch the prototype
-        return;
+        return
     }
     this[storeKey].forEach(propKeyOrFunction => {
         const prop =
@@ -20,7 +20,7 @@ function runDisposersOnWillUnmount() {
             prop()
         }
     })
-    this[storeKey] = []
+    // this[storeKey] = []
 }
 
 export function disposeOnUnmount(target, propertyKeyOrFunction) {
@@ -46,7 +46,7 @@ export function disposeOnUnmount(target, propertyKeyOrFunction) {
 
     // tweak the component class componentWillUnmount if not done already
     if (!componentWasAlreadyModified) {
-        patch(target, "componentWillUnmount", runDisposersOnWillUnmount, false)
+        patch(target, "componentWillUnmount", runDisposersOnWillUnmount)
     }
 
     // return the disposer as is if invoked as a non decorator

--- a/src/disposeOnUnmount.js
+++ b/src/disposeOnUnmount.js
@@ -46,7 +46,7 @@ export function disposeOnUnmount(target, propertyKeyOrFunction) {
 
     // tweak the component class componentWillUnmount if not done already
     if (!componentWasAlreadyModified) {
-        patch(target, "componentWillUnmount", runDisposersOnWillUnmount)
+        patch(target, "componentWillUnmount", false, runDisposersOnWillUnmount)
     }
 
     // return the disposer as is if invoked as a non decorator

--- a/src/disposeOnUnmount.js
+++ b/src/disposeOnUnmount.js
@@ -46,7 +46,7 @@ export function disposeOnUnmount(target, propertyKeyOrFunction) {
 
     // tweak the component class componentWillUnmount if not done already
     if (!componentWasAlreadyModified) {
-        patch(target, "componentWillUnmount", false, runDisposersOnWillUnmount)
+        patch(target, "componentWillUnmount", runDisposersOnWillUnmount)
     }
 
     // return the disposer as is if invoked as a non decorator

--- a/src/disposeOnUnmount.js
+++ b/src/disposeOnUnmount.js
@@ -20,7 +20,7 @@ function runDisposersOnWillUnmount() {
             prop()
         }
     })
-    // this[storeKey] = []
+    this[storeKey] = []
 }
 
 export function disposeOnUnmount(target, propertyKeyOrFunction) {

--- a/src/observer.js
+++ b/src/observer.js
@@ -91,8 +91,8 @@ export const errorsReporter = new EventEmitter()
  * Utilities
  */
 
-function patch(target, funcName, runMixinFirst = false) {
-    newPatch(target, funcName, reactiveMixin[funcName], runMixinFirst)
+function patch(target, funcName) {
+    newPatch(target, funcName, false, reactiveMixin[funcName])
 }
 
 function shallowEqual(objA, objB) {

--- a/src/observer.js
+++ b/src/observer.js
@@ -92,7 +92,7 @@ export const errorsReporter = new EventEmitter()
  */
 
 function patch(target, funcName) {
-    newPatch(target, funcName, false, reactiveMixin[funcName])
+    newPatch(target, funcName, reactiveMixin[funcName])
 }
 
 function shallowEqual(objA, objB) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -50,18 +50,22 @@ export function patch(target, methodName, mixinMethod, runMixinFirst = false) {
 
         realRunning = true
 
+        let retVal
+
         try {
             mixins.pre.forEach(pre => {
                 pre.apply(this, args)
             })
 
             if (realMethod !== undefined && realMethod !== null) {
-                realMethod.apply(this, args)
+                retVal = realMethod.apply(this, args)
             }
 
             mixins.post.forEach(post => {
                 post.apply(this, args)
             })
+
+            return retVal
         } finally {
             realRunning = false
         }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -51,8 +51,6 @@ export function patch(target, methodName, mixinMethod, runMixinFirst = false) {
         realRunning = true
 
         try {
-            const mixins = getMixins(this, methodName)
-
             mixins.pre.forEach(pre => {
                 pre.apply(this, args)
             })

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -78,13 +78,13 @@ export function patch(target, methodName, forcePatch, ...mixinMethods) {
             return actualValue
         },
         set: function(value) {
-            // when it is an instance of the prototype/a child prototype patch that particular case again separately
-            if (this !== target) {
+            if (this === target) {
+                actualValue = wrapFunction(value, mixins)
+            } else {
+                // when it is an instance of the prototype/a child prototype patch that particular case again separately
                 // we don't need to pass any mixin functions since the structure is shared
                 patch(this, methodName, true)
                 this[methodName] = value
-            } else {
-                actualValue = wrapFunction(value, mixins)
             }
         },
         configurable: true

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -14,8 +14,8 @@ export function newSymbol(name) {
     return symbol
 }
 
-const mobxMixins = newSymbol("Mixins")
-const mobxMixin = newSymbol("Mixin")
+const mobxMixins = newSymbol("patchMixins")
+const mobxMixin = newSymbol("patchMixin")
 
 function getMixins(target, methodName) {
     const mixins = (target[mobxMixins] = target[mobxMixins] || {})

--- a/test/disposeOnUnmount.test.js
+++ b/test/disposeOnUnmount.test.js
@@ -351,7 +351,12 @@ describe("super calls should work", async () => {
     async function test(baseObserver, cObserver) {
         const events = []
 
+        const sharedMethod = jest.fn()
+
         class BaseComponent extends React.Component {
+            @disposeOnUnmount
+            method0 = sharedMethod
+
             @disposeOnUnmount
             methodA = jest.fn()
 
@@ -365,6 +370,9 @@ describe("super calls should work", async () => {
         }
 
         class C extends BaseComponent {
+            @disposeOnUnmount
+            method0 = sharedMethod
+
             @disposeOnUnmount
             methodB = jest.fn()
 
@@ -394,6 +402,7 @@ describe("super calls should work", async () => {
             C,
             ref => {
                 expect(events).toEqual(["baseDidMount", "CDidMount"])
+                expect(sharedMethod).toHaveBeenCalledTimes(0)
             },
             ref => {
                 expect(events).toEqual([
@@ -402,6 +411,7 @@ describe("super calls should work", async () => {
                     "baseWillUnmount",
                     "CWillUnmount"
                 ])
+                expect(sharedMethod).toHaveBeenCalledTimes(2)
             }
         )
     }

--- a/test/disposeOnUnmount.test.js
+++ b/test/disposeOnUnmount.test.js
@@ -348,7 +348,7 @@ test("custom patching should work", async () => {
 })
 
 describe("super calls should work", async () => {
-    async function test(baseObserver, cObserver) {
+    async function doTest(baseObserver, cObserver) {
         const events = []
 
         const sharedMethod = jest.fn()
@@ -417,21 +417,21 @@ describe("super calls should work", async () => {
     }
 
     it("none is observer", async () => {
-        await test(false, false)
+        await doTest(false, false)
     })
     it("base is observer", async () => {
-        await test(true, false)
+        await doTest(true, false)
     })
     it("C is observer", async () => {
-        await test(false, true)
+        await doTest(false, true)
     })
     it("both observers", async () => {
-        await test(true, true)
+        await doTest(true, true)
     })
 })
 
 it("componentDidMount should be different between components", async () => {
-    async function test(withObserver) {
+    async function doTest(withObserver) {
         const events = []
 
         class A extends React.Component {
@@ -500,6 +500,6 @@ it("componentDidMount should be different between components", async () => {
         expect(events).toEqual(["mountA", "unmountA", "mountB", "unmountB"])
     }
 
-    await test(true)
-    await test(false)
+    await doTest(true)
+    await doTest(false)
 })

--- a/test/disposeOnUnmount.test.js
+++ b/test/disposeOnUnmount.test.js
@@ -17,8 +17,8 @@ async function testComponent(C, afterMount, afterUnmount) {
 
     await asyncReactDOMRender(null, testRoot)
 
-    expect(cref.methodA).toHaveBeenCalled()
-    expect(cref.methodB).toHaveBeenCalled()
+    expect(cref.methodA).toHaveBeenCalledTimes(1)
+    expect(cref.methodB).toHaveBeenCalledTimes(1)
     if (afterUnmount) {
         afterUnmount(cref)
     }
@@ -134,8 +134,8 @@ describe("without observer", () => {
                 expect(methodD).not.toHaveBeenCalled()
             },
             () => {
-                expect(methodC).toHaveBeenCalled()
-                expect(methodD).toHaveBeenCalled()
+                expect(methodC).toHaveBeenCalledTimes(1)
+                expect(methodD).toHaveBeenCalledTimes(1)
             }
         )
     })
@@ -256,8 +256,8 @@ describe("with observer", () => {
                 expect(methodD).not.toHaveBeenCalled()
             },
             () => {
-                expect(methodC).toHaveBeenCalled()
-                expect(methodD).toHaveBeenCalled()
+                expect(methodC).toHaveBeenCalledTimes(1)
+                expect(methodD).toHaveBeenCalledTimes(1)
             }
         )
     })
@@ -352,6 +352,9 @@ describe("super calls should work", async () => {
         const events = []
 
         class BaseComponent extends React.Component {
+            @disposeOnUnmount
+            methodA = jest.fn()
+
             componentDidMount() {
                 events.push("baseDidMount")
             }
@@ -362,6 +365,9 @@ describe("super calls should work", async () => {
         }
 
         class C extends BaseComponent {
+            @disposeOnUnmount
+            methodB = jest.fn()
+
             componentDidMount() {
                 super.componentDidMount()
                 events.push("CDidMount")
@@ -371,15 +377,6 @@ describe("super calls should work", async () => {
                 super.componentWillUnmount()
                 events.push("CWillUnmount")
             }
-
-            @disposeOnUnmount
-            methodA = jest.fn()
-            @disposeOnUnmount
-            methodB = jest.fn()
-            @disposeOnUnmount
-            methodC = null
-            @disposeOnUnmount
-            methodD = undefined
 
             render() {
                 return null

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -1,0 +1,277 @@
+import * as React from "react"
+import { createTestRoot, asyncReactDOMRender } from "./"
+import { patch } from "../src/utils/utils"
+
+const testRoot = createTestRoot()
+
+async function testComponent(C, didMountMixin, willUnmountMixin, doMixinTest = true) {
+    if (doMixinTest) {
+        expect(didMountMixin).not.toHaveBeenCalled()
+        expect(willUnmountMixin).not.toHaveBeenCalled()
+    }
+
+    await asyncReactDOMRender(<C />, testRoot)
+
+    if (doMixinTest) {
+        expect(didMountMixin).toHaveBeenCalledTimes(1)
+        expect(willUnmountMixin).not.toHaveBeenCalled()
+    }
+
+    await asyncReactDOMRender(null, testRoot)
+
+    if (doMixinTest) {
+        expect(didMountMixin).toHaveBeenCalledTimes(1)
+        expect(willUnmountMixin).toHaveBeenCalledTimes(1)
+    }
+}
+
+test("no overrides", async () => {
+    const cdm = jest.fn()
+    const cwu = jest.fn()
+    class C extends React.Component {
+        render() {
+            return null
+        }
+    }
+    patch(C.prototype, "componentDidMount", false, cdm)
+    patch(C.prototype, "componentWillUnmount", false, cwu)
+
+    await testComponent(C, cdm, cwu)
+})
+
+test("prototype overrides", async () => {
+    const cdm = jest.fn()
+    const cwu = jest.fn()
+    let cdmCalls = 0
+    let cwuCalls = 0
+    class C extends React.Component {
+        componentDidMount() {
+            cdmCalls++
+        }
+        componentWillUnmount() {
+            cwuCalls++
+        }
+        render() {
+            return null
+        }
+    }
+    patch(C.prototype, "componentDidMount", false, cdm)
+    patch(C.prototype, "componentWillUnmount", false, cwu)
+
+    await testComponent(C, cdm, cwu)
+    expect(cdmCalls).toBe(1)
+    expect(cwuCalls).toBe(1)
+})
+
+test("arrow function overrides", async () => {
+    const cdm = jest.fn()
+    const cwu = jest.fn()
+    let cdmCalls = 0
+    let cwuCalls = 0
+    class C extends React.Component {
+        componentDidMount = () => {
+            cdmCalls++
+        }
+        componentWillUnmount = () => {
+            cwuCalls++
+        }
+        render() {
+            return null
+        }
+    }
+    patch(C.prototype, "componentDidMount", false, cdm)
+    patch(C.prototype, "componentWillUnmount", false, cwu)
+
+    await testComponent(C, cdm, cwu)
+    expect(cdmCalls).toBe(1)
+    expect(cwuCalls).toBe(1)
+})
+
+test("recursive calls", async () => {
+    const cdm = jest.fn()
+    const cwu = jest.fn()
+    let cdmCalls = 0
+    let cwuCalls = 0
+    class C extends React.Component {
+        componentDidMount() {
+            cdmCalls++
+            while (cdmCalls < 10) {
+                this.componentDidMount()
+            }
+        }
+        componentWillUnmount() {
+            cwuCalls++
+            while (cwuCalls < 10) {
+                this.componentWillUnmount()
+            }
+        }
+        render() {
+            return null
+        }
+    }
+    patch(C.prototype, "componentDidMount", false, cdm)
+    patch(C.prototype, "componentWillUnmount", false, cwu)
+
+    await testComponent(C, cdm, cwu)
+    expect(cdmCalls).toBe(10)
+    expect(cwuCalls).toBe(10)
+})
+
+test("prototype + arrow function overrides", async () => {
+    const cdm = jest.fn()
+    const cwu = jest.fn()
+    let cdmCalls = 0
+    let cwuCalls = 0
+    class C extends React.Component {
+        componentDidMount() {
+            cdmCalls++
+        }
+        componentWillUnmount() {
+            cwuCalls++
+        }
+        render() {
+            return null
+        }
+        constructor(props) {
+            super(props)
+            this.componentDidMount = () => {
+                cdmCalls++
+            }
+            this.componentWillUnmount = () => {
+                cwuCalls++
+            }
+        }
+    }
+    patch(C.prototype, "componentDidMount", false, cdm)
+    patch(C.prototype, "componentWillUnmount", false, cwu)
+
+    await testComponent(C, cdm, cwu)
+    expect(cdmCalls).toBe(1)
+    expect(cwuCalls).toBe(1)
+})
+
+describe("inheritance with prototype methods", async () => {
+    async function doTest(patchBase, patchOther, callSuper) {
+        const cdm = jest.fn()
+        const cwu = jest.fn()
+        let cdmCalls = 0
+        let cwuCalls = 0
+
+        class B extends React.Component {
+            componentDidMount() {
+                cdmCalls++
+            }
+            componentWillUnmount() {
+                cwuCalls++
+            }
+        }
+
+        class C extends B {
+            componentDidMount() {
+                if (callSuper) {
+                    super.componentDidMount()
+                }
+                cdmCalls++
+            }
+            componentWillUnmount() {
+                if (callSuper) {
+                    super.componentWillUnmount()
+                }
+                cwuCalls++
+            }
+            render() {
+                return null
+            }
+        }
+
+        if (patchBase) {
+            patch(B.prototype, "componentDidMount", false, cdm)
+            patch(B.prototype, "componentWillUnmount", false, cwu)
+        }
+        if (patchOther) {
+            patch(C.prototype, "componentDidMount", false, cdm)
+            patch(C.prototype, "componentWillUnmount", false, cwu)
+        }
+
+        await testComponent(C, cdm, cwu, patchBase || patchOther)
+        expect(cdmCalls).toBe(callSuper ? 2 : 1)
+        expect(cwuCalls).toBe(callSuper ? 2 : 1)
+    }
+
+    for (const base of [false, true]) {
+        for (const other of [false, true]) {
+            for (const callSuper of [false, true]) {
+                test(`base: ${base}, other: ${other}, callSuper: ${callSuper}`, async () => {
+                    if (base && !other && !callSuper) {
+                        // this one is expected to fail, since we are patching only the base and the other one totally overrides the base method
+                        try {
+                            await doTest(base, other, callSuper)
+                            fail("should have failed")
+                        } catch (e) {}
+                    } else {
+                        await doTest(base, other, callSuper)
+                    }
+                })
+            }
+        }
+    }
+})
+
+describe("inheritance with arrow functions", async () => {
+    async function doTest(patchBase, patchOther, callSuper) {
+        const cdm = jest.fn()
+        const cwu = jest.fn()
+        let cdmCalls = 0
+        let cwuCalls = 0
+
+        class B extends React.Component {
+            componentDidMount() {
+                cdmCalls++
+            }
+            componentWillUnmount() {
+                cwuCalls++
+            }
+        }
+
+        class C extends B {
+            componentDidMount = () => {
+                if (callSuper) {
+                    super.componentDidMount()
+                }
+                cdmCalls++
+            }
+            componentWillUnmount = () => {
+                if (callSuper) {
+                    super.componentWillUnmount()
+                }
+                cwuCalls++
+            }
+            render() {
+                return null
+            }
+        }
+
+        if (patchBase) {
+            patch(B.prototype, "componentDidMount", false, cdm)
+            patch(B.prototype, "componentWillUnmount", false, cwu)
+        }
+        if (patchOther) {
+            patch(C.prototype, "componentDidMount", false, cdm)
+            patch(C.prototype, "componentWillUnmount", false, cwu)
+        }
+
+        await testComponent(C, cdm, cwu, patchBase || patchOther)
+        expect(cdmCalls).toBe(callSuper ? 2 : 1)
+        expect(cwuCalls).toBe(callSuper ? 2 : 1)
+    }
+
+    for (const base of [false, true]) {
+        for (const other of [false, true]) {
+            for (const callSuper of [false, true]) {
+                test(`base: ${base}, other: ${other}, callSuper: ${callSuper}`, async () => {
+                    await doTest(base, other, callSuper)
+                })
+            }
+        }
+    }
+})

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -203,7 +203,7 @@ describe("inheritance with prototype methods", async () => {
             for (const callSuper of [false, true]) {
                 test(`base: ${base}, other: ${other}, callSuper: ${callSuper}`, async () => {
                     if (base && !other && !callSuper) {
-                        // this one is expected to fail, since we are patching only the base and the other one totally overrides the base method
+                        // this one is expected to fail, since we are patching only the base and the other one totally ignores the base method
                         try {
                             await doTest(base, other, callSuper)
                             fail("should have failed")

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -33,8 +33,8 @@ test("no overrides", async () => {
             return null
         }
     }
-    patch(C.prototype, "componentDidMount", false, cdm)
-    patch(C.prototype, "componentWillUnmount", false, cwu)
+    patch(C.prototype, "componentDidMount", cdm)
+    patch(C.prototype, "componentWillUnmount", cwu)
 
     await testComponent(C, cdm, cwu)
 })
@@ -55,8 +55,8 @@ test("prototype overrides", async () => {
             return null
         }
     }
-    patch(C.prototype, "componentDidMount", false, cdm)
-    patch(C.prototype, "componentWillUnmount", false, cwu)
+    patch(C.prototype, "componentDidMount", cdm)
+    patch(C.prototype, "componentWillUnmount", cwu)
 
     await testComponent(C, cdm, cwu)
     expect(cdmCalls).toBe(1)
@@ -79,8 +79,8 @@ test("arrow function overrides", async () => {
             return null
         }
     }
-    patch(C.prototype, "componentDidMount", false, cdm)
-    patch(C.prototype, "componentWillUnmount", false, cwu)
+    patch(C.prototype, "componentDidMount", cdm)
+    patch(C.prototype, "componentWillUnmount", cwu)
 
     await testComponent(C, cdm, cwu)
     expect(cdmCalls).toBe(1)
@@ -109,8 +109,8 @@ test("recursive calls", async () => {
             return null
         }
     }
-    patch(C.prototype, "componentDidMount", false, cdm)
-    patch(C.prototype, "componentWillUnmount", false, cwu)
+    patch(C.prototype, "componentDidMount", cdm)
+    patch(C.prototype, "componentWillUnmount", cwu)
 
     await testComponent(C, cdm, cwu)
     expect(cdmCalls).toBe(10)
@@ -142,8 +142,8 @@ test("prototype + arrow function overrides", async () => {
             }
         }
     }
-    patch(C.prototype, "componentDidMount", false, cdm)
-    patch(C.prototype, "componentWillUnmount", false, cwu)
+    patch(C.prototype, "componentDidMount", cdm)
+    patch(C.prototype, "componentWillUnmount", cwu)
 
     await testComponent(C, cdm, cwu)
     expect(cdmCalls).toBe(1)
@@ -185,12 +185,12 @@ describe("inheritance with prototype methods", async () => {
         }
 
         if (patchBase) {
-            patch(B.prototype, "componentDidMount", false, cdm)
-            patch(B.prototype, "componentWillUnmount", false, cwu)
+            patch(B.prototype, "componentDidMount", cdm)
+            patch(B.prototype, "componentWillUnmount", cwu)
         }
         if (patchOther) {
-            patch(C.prototype, "componentDidMount", false, cdm)
-            patch(C.prototype, "componentWillUnmount", false, cwu)
+            patch(C.prototype, "componentDidMount", cdm)
+            patch(C.prototype, "componentWillUnmount", cwu)
         }
 
         await testComponent(C, cdm, cwu, patchBase || patchOther)
@@ -252,12 +252,12 @@ describe("inheritance with arrow functions", async () => {
         }
 
         if (patchBase) {
-            patch(B.prototype, "componentDidMount", false, cdm)
-            patch(B.prototype, "componentWillUnmount", false, cwu)
+            patch(B.prototype, "componentDidMount", cdm)
+            patch(B.prototype, "componentWillUnmount", cwu)
         }
         if (patchOther) {
-            patch(C.prototype, "componentDidMount", false, cdm)
-            patch(C.prototype, "componentWillUnmount", false, cwu)
+            patch(C.prototype, "componentDidMount", cdm)
+            patch(C.prototype, "componentWillUnmount", cwu)
         }
 
         await testComponent(C, cdm, cwu, patchBase || patchOther)


### PR DESCRIPTION
Fixes #581 

Basically it goes back to the "non-optimized" property definition that was at the beginning, since that one works well with inheritance, while the optimized version does not due to the reusage of variables for the instance, the prototype, the possible prototype of the prototype etc.

Either way I don't think it is a big deal since each class is patched only once, and only per class, not per instance.