### PR TITLE
observableProps implementation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
-            // Note; this config requires node 8.4 or higher
             "type": "node",
-            "protocol": "auto",
+            "name": "debug unit tests",
             "request": "launch",
-            "name": "debug unit test",
-            "stopOnEntry": false,
-            "program": "${workspaceRoot}/node_modules/jest-cli/bin/jest.js",
-            "args": ["--verbose", "--testRegex",".*", "-i", "${file}"],
-            "runtimeArgs": [
-                "--nolazy"
-            ],
-            "sourceMaps": true
+            "args": ["--runInBand"],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ See the [official documentation](http://mobxjs.github.io/mobx/intro/overview.htm
 
 ## Boilerplate projects that use mobx-react
 
-*   Minimal MobX, React, ES6, JSX, Hot reloading: [MobX-React-Boilerplate](https://github.com/mobxjs/mobx-react-boilerplate)
-*   TodoMVC MobX, React, ES6, JSX, Hot reloading: [MobX-React-TodoMVC](https://github.com/mobxjs/mobx-react-todomvc)
-*   Minimal MobX, React, Typescript, TSX: [MobX-React-Typescript-Boilerplate](https://github.com/mobxjs/mobx-react-typescript-boilerplate)
-*   Minimal MobX, React, ES6(babel), JSPM with hot reloading modules:
+-   Minimal MobX, React, ES6, JSX, Hot reloading: [MobX-React-Boilerplate](https://github.com/mobxjs/mobx-react-boilerplate)
+-   TodoMVC MobX, React, ES6, JSX, Hot reloading: [MobX-React-TodoMVC](https://github.com/mobxjs/mobx-react-todomvc)
+-   Minimal MobX, React, Typescript, TSX: [MobX-React-Typescript-Boilerplate](https://github.com/mobxjs/mobx-react-typescript-boilerplate)
+-   Minimal MobX, React, ES6(babel), JSPM with hot reloading modules:
     [jspm-react](https://github.com/capaj/jspm-react)
-*   React Native Counter: [Mobx-React-Native-Counter](https://github.com/bartonhammond/mobx-react-native-counter)
+-   React Native Counter: [Mobx-React-Native-Counter](https://github.com/bartonhammond/mobx-react-native-counter)
 
 ## API documentation
 
@@ -39,7 +39,7 @@ See the [official documentation](http://mobxjs.github.io/mobx/intro/overview.htm
 
 Function (and decorator) that converts a React component definition, React component class or stand-alone render function into a reactive component, which tracks which observables are used by `render` and automatically re-renders the component when one of these values changes.
 
-Apart from observables passed/injected in or defined inside an `observer` component, `this.props` and `this.state` are also observables themselves, so the component will react to all changes in props and state that are  used by `render`.
+Apart from observables passed/injected in or defined inside an `observer` component, `this.props` and `this.state` are also observables themselves, so the component will react to all changes in props and state that are used by `render`.
 
 See the [MobX](https://mobxjs.github.io/mobx/refguide/observer-component.html) documentation for more details.
 
@@ -151,7 +151,7 @@ To avoid leaking memory, call `useStaticRendering(true)` when using server side 
 ```javascript
 import { useStaticRendering } from "mobx-react"
 
-useStaticRendering(true);
+useStaticRendering(true)
 ```
 
 This makes sure the component won't try to react to any future data changes.
@@ -198,20 +198,20 @@ class TodoView extends React.Component {
 }
 ```
 
-*   `componentWillReact` doesn't take arguments
-*   `componentWillReact` won't fire before the initial render (use use `componentDidMount` or `constructor` instead)
+-   `componentWillReact` doesn't take arguments
+-   `componentWillReact` won't fire before the initial render (use use `componentDidMount` or `constructor` instead)
 
 ### `PropTypes`
 
 MobX-react provides the following additional `PropTypes` which can be used to validate against MobX structures:
 
-*   `observableArray`
-*   `observableArrayOf(React.PropTypes.number)`
-*   `observableMap`
-*   `observableObject`
-*   `arrayOrObservableArray`
-*   `arrayOrObservableArrayOf(React.PropTypes.number)`
-*   `objectOrObservableObject`
+-   `observableArray`
+-   `observableArrayOf(React.PropTypes.number)`
+-   `observableMap`
+-   `observableObject`
+-   `arrayOrObservableArray`
+-   `arrayOrObservableArrayOf(React.PropTypes.number)`
+-   `objectOrObservableObject`
 
 Use `import { PropTypes } from "mobx-react"` to import them, then use for example `PropTypes.observableArray`
 
@@ -257,12 +257,12 @@ class MessageList extends React.Component {
 
 Notes:
 
-*   If a component asks for a store and receives a store via a property with the same name, the property takes precedence. Use this to your advantage when testing!
-*   If updates to an observable store are not triggering `render()`, make sure you are using Class methods for React lifecycle hooks such as `componentWillMount() {}`, using `componentWillMount = () => {}` will create a property on the instance and cause conflicts with mobx-react.
-*   Values provided through `Provider` should be final, to avoid issues like mentioned in [React #2517](https://github.com/facebook/react/issues/2517) and [React #3973](https://github.com/facebook/react/pull/3973), where optimizations might stop the propagation of new context. Instead, make sure that if you put things in `context` that might change over time, that they are `@observable` or provide some other means to listen to changes, like callbacks. However, if your stores will change over time, like an observable value of another store, MobX will warn you. To suppress that warning explicitly, you can use `suppressChangedStoreWarning={true}` as a prop at your own risk.
-*   When using both `@inject` and `@observer`, make sure to apply them in the correct order: `observer` should be the inner decorator, `inject` the outer. There might be additional decorators in between.
-*   The original component wrapped by `inject` is available as the `wrappedComponent` property of the created higher order component.
-*   For mounted component instances, the wrapped component instance is available through the `wrappedInstance` property (except for stateless components).
+-   If a component asks for a store and receives a store via a property with the same name, the property takes precedence. Use this to your advantage when testing!
+-   If updates to an observable store are not triggering `render()`, make sure you are using Class methods for React lifecycle hooks such as `componentWillMount() {}`, using `componentWillMount = () => {}` will create a property on the instance and cause conflicts with mobx-react.
+-   Values provided through `Provider` should be final, to avoid issues like mentioned in [React #2517](https://github.com/facebook/react/issues/2517) and [React #3973](https://github.com/facebook/react/pull/3973), where optimizations might stop the propagation of new context. Instead, make sure that if you put things in `context` that might change over time, that they are `@observable` or provide some other means to listen to changes, like callbacks. However, if your stores will change over time, like an observable value of another store, MobX will warn you. To suppress that warning explicitly, you can use `suppressChangedStoreWarning={true}` as a prop at your own risk.
+-   When using both `@inject` and `@observer`, make sure to apply them in the correct order: `observer` should be the inner decorator, `inject` the outer. There might be additional decorators in between.
+-   The original component wrapped by `inject` is available as the `wrappedComponent` property of the created higher order component.
+-   For mounted component instances, the wrapped component instance is available through the `wrappedInstance` property (except for stateless components).
 
 #### Inject as function
 
@@ -443,6 +443,30 @@ class SomeComponent extends React.Component {
             reaction(...),
             reaction(...)
         ])
+    }
+}
+```
+
+### observableProps(componentInstance) _[Requires MobX >= 5]_
+
+Function that converts your props into fully reactive (observable) props.
+This allows you to, for example, create reactions/autorun/computed over individual props rather than the whole props object.
+
+```javascript
+import { observer, observableProps } from "mobx-react"
+
+<NameAndAge first="Mary" last="Poppins" age={30} />
+
+@observer
+class NameAndAge extends React.Component {
+    obsProps = observableProps(this)
+
+    @computed
+    get fullName() {
+        // this computed will only recompute when any of these props change
+        // if we were using props instead it would also recompute if age
+        // (or any other property) changed
+        return this.obsProps.first + " " + this.obsProps.last;
     }
 }
 ```

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -87,6 +87,8 @@ export class Observer extends React.Component<
 
 export function useStaticRendering(value: boolean): void
 
+export function observableProps<P>(target: React.Component<P, any>): P
+
 /**
  * Enable dev tool support, makes sure that renderReport emits events.
  */

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ export {
     useStaticRendering
 } from "./observer"
 
+export { observableProps } from "./observableProps"
+
 export { default as Provider } from "./Provider"
 export { default as inject } from "./inject"
 export { disposeOnUnmount } from "./disposeOnUnmount"

--- a/src/observableProps.js
+++ b/src/observableProps.js
@@ -1,0 +1,60 @@
+import { observable, reaction, set, remove } from "mobx"
+import { disposeOnUnmount } from "./disposeOnUnmount"
+import { isObserverComponent } from "./observer"
+import { getMobxCapabilities } from "./utils/mobxCapabilities"
+
+function updateObservableObject(oldObj, newObj) {
+    // add/update props
+    Object.keys(newObj).forEach(propName => {
+        const value = newObj[propName]
+
+        // it is ok to call set even if the value doesn't change
+        // since internally it won't trigger a change if the value is the same
+        set(oldObj, propName, value)
+    })
+
+    // remove removed props
+    Object.keys(oldObj).forEach(propName => {
+        if (!(propName in newObj)) {
+            remove(oldObj, propName)
+        }
+    })
+}
+
+function observableProperty(methodName, component, componentPropName) {
+    if (!getMobxCapabilities().canDetectNewProperties) {
+        throw new Error(`[mobx-react] ${methodName} requires mobx 5 or higher`)
+    }
+
+    if (!isObserverComponent(component)) {
+        throw new Error(`[mobx-react] ${methodName} only works on observer components`)
+    }
+
+    // to properly use "deep" properties the passed object should be observable
+    // or else react won't trigger a re-render by itself since the object ref will be the same
+    const observed = observable({}, undefined, { deep: false })
+
+    disposeOnUnmount(
+        component,
+        reaction(
+            () => component[componentPropName],
+            unobserved => {
+                if (unobserved) {
+                    updateObservableObject(observed, unobserved)
+                } else {
+                    // remove all props if props is null (sometimes it happens)
+                    Object.keys(observed).forEach(propName => {
+                        remove(observed, propName)
+                    })
+                }
+            },
+            { fireImmediately: true }
+        )
+    )
+
+    return observed
+}
+
+export function observableProps(component) {
+    return observableProperty("observableProps", component, "props")
+}

--- a/src/observer.js
+++ b/src/observer.js
@@ -8,6 +8,7 @@ import { patch as newPatch, newSymbol } from "./utils/utils"
 
 const mobxAdminProperty = $mobx || "$mobx"
 const mobxIsUnmounted = newSymbol("isUnmounted")
+const mobxIsObserver = newSymbol("isObserver")
 
 /**
  * dev tool support
@@ -347,6 +348,7 @@ export function observer(arg1, arg2) {
     }
 
     const target = componentClass.prototype || componentClass
+    target[mobxIsObserver] = true
     mixinLifecycleEvents(target)
     componentClass.isMobXReactObserver = true
     makeObservableProp(target, "props")
@@ -420,4 +422,8 @@ const ObserverPropsCheck = (props, key, componentName, location, propFullName) =
 Observer.propTypes = {
     render: ObserverPropsCheck,
     children: ObserverPropsCheck
+}
+
+export function isObserverComponent(component) {
+    return component instanceof React.Component && component[mobxIsObserver]
 }

--- a/src/utils/mobxCapabilities.js
+++ b/src/utils/mobxCapabilities.js
@@ -1,0 +1,29 @@
+import { observable, runInAction, reaction } from "mobx"
+
+let capabilities
+
+export function getMobxCapabilities() {
+    if (!capabilities) {
+        capabilities = {
+            canDetectNewProperties: canDetectNewProperties()
+        }
+    }
+    return capabilities
+}
+
+function canDetectNewProperties() {
+    // check that support detecting new props as they get added to objects
+    let passed = false
+    const obj = observable({})
+    const r = reaction(
+        () => obj && obj.x,
+        () => {
+            passed = true
+        }
+    )
+    runInAction(() => {
+        obj.x = 5
+    })
+    r()
+    return passed
+}

--- a/test/observableProps.test.js
+++ b/test/observableProps.test.js
@@ -1,0 +1,267 @@
+import * as React from "react"
+import * as mobx from "mobx"
+import { observer } from "../src"
+import { observableProps } from "../src/observableProps"
+import { createTestRoot, asyncReactDOMRender } from "./index"
+import { getMobxCapabilities } from "../src/utils/mobxCapabilities"
+
+const testRoot = createTestRoot()
+
+if (!getMobxCapabilities().canDetectNewProperties) {
+    it("observableProps should throw when using mobx4", async () => {
+        let errorThrown
+
+        const C = observer(
+            class C extends React.Component {
+                constructor(props) {
+                    super(props)
+                    try {
+                        this.oProps = observableProps(this)
+                    } catch (e) {
+                        errorThrown = e
+                    }
+                }
+
+                render() {
+                    return null
+                }
+            }
+        )
+
+        await asyncReactDOMRender(<C />, testRoot)
+        expect(errorThrown).toBeTruthy()
+        expect(errorThrown.message).toMatch("observableProps requires mobx 5 or higher")
+    })
+} else {
+    describe(`verify change of non-accessed prop do not trigger reaction`, async () => {
+        const computedCalls = []
+        let renders = 0
+
+        const Component = observer(
+            class Component extends React.Component {
+                constructor(props) {
+                    super(props)
+
+                    this.oProps = observableProps(this)
+
+                    this.computedWithProp1 = mobx.computed(() => {
+                        const prop1Value = this.oProps.prop1
+                        computedCalls.push("prop1: " + JSON.stringify(prop1Value))
+                        return prop1Value
+                    })
+
+                    this.computedWithProp2 = mobx.computed(() => {
+                        const prop2Value = this.oProps.prop2
+                        computedCalls.push("prop2: " + JSON.stringify(prop2Value))
+                        return prop2Value
+                    })
+
+                    this.deepComputed = mobx.computed(() => {
+                        const prop3Value = this.oProps.prop3 && this.oProps.prop3.x
+                        computedCalls.push("prop3.x: " + JSON.stringify(prop3Value))
+                        return prop3Value
+                    })
+
+                    this.computedComponent = mobx.computed(() => {
+                        const value = this.oProps.componentProp
+                        computedCalls.push("componentProp: " + JSON.stringify(!!value))
+                        return value
+                    })
+                }
+
+                render() {
+                    this.computedWithProp1.get()
+                    this.computedWithProp2.get()
+                    this.deepComputed.get()
+                    this.computedComponent.get()
+                    renders++
+                    return null
+                }
+            }
+        )
+
+        const Container = observer(
+            class Container extends React.Component {
+                constructor(props) {
+                    super(props)
+                    this.oProps = observableProps(this)
+                }
+
+                render() {
+                    return this.oProps.renderStore.get()()
+                }
+            }
+        )
+
+        const renderFnStore = mobx.observable.box(function() {
+            return null
+        })
+
+        beforeEach(() => {
+            computedCalls.length = 0
+            renders = 0
+        })
+
+        it("initial state", async () => {
+            await asyncReactDOMRender(<Container renderStore={renderFnStore} />, testRoot)
+            renderFnStore.set(function() {
+                return <Component prop1={1} />
+            })
+            expect(computedCalls).toEqual([
+                "prop1: 1",
+                "prop2: undefined",
+                "prop3.x: undefined",
+                "componentProp: false"
+            ])
+            expect(renders).toBe(1)
+        })
+
+        it("prop1 changed from 1 to 2, prop2 is untouched", async () => {
+            renderFnStore.set(function() {
+                return <Component prop1={2} />
+            })
+            expect(computedCalls).toEqual(["prop1: 2"])
+            expect(renders).toBe(1)
+        })
+
+        it("prop1 is untouched, prop2 appears", async () => {
+            renderFnStore.set(function() {
+                return <Component prop1={2} prop2={1} />
+            })
+            expect(computedCalls).toEqual(["prop2: 1"])
+            expect(renders).toBe(1)
+        })
+
+        it("prop1 is untouched, prop2 changes from 1 to 2", async () => {
+            renderFnStore.set(function() {
+                return <Component prop1={2} prop2={2} />
+            })
+            expect(computedCalls).toEqual(["prop2: 2"])
+            expect(renders).toBe(1)
+        })
+
+        it("prop2 is untouched, prop1 changes from 2 to 1", async () => {
+            renderFnStore.set(function() {
+                return <Component prop1={1} prop2={2} />
+            })
+            expect(computedCalls).toEqual(["prop1: 1"])
+            expect(renders).toBe(1)
+        })
+
+        it("nothing changed - no recalc", async () => {
+            renderFnStore.set(function() {
+                return <Component prop1={1} prop2={2} />
+            })
+            expect(computedCalls).toEqual([])
+            expect(renders).toBe(0) // no re-render needed
+        })
+
+        it("prop1 disappear, prop2 is untouched", async () => {
+            renderFnStore.set(function() {
+                return <Component prop2={2} />
+            })
+            expect(computedCalls).toEqual(["prop1: undefined"])
+            expect(renders).toBe(1)
+        })
+
+        it("if we replace prop2 to prop1, both computeds should be recalculated", async () => {
+            renderFnStore.set(function() {
+                return <Component prop1={2} />
+            })
+            expect(computedCalls).toEqual(["prop1: 2", "prop2: undefined"])
+            expect(renders).toBe(1)
+        })
+
+        it("remove prop1 should only recalc prop1", async () => {
+            renderFnStore.set(function() {
+                return <Component />
+            })
+            expect(computedCalls).toEqual(["prop1: undefined"])
+            expect(renders).toBe(1)
+        })
+
+        it("correctly catch prop1 appearing after disappearing", async () => {
+            renderFnStore.set(function() {
+                return <Component prop1={2} />
+            })
+            expect(computedCalls).toEqual(["prop1: 2"])
+            expect(renders).toBe(1)
+        })
+
+        it("swap again - all recalculated", async () => {
+            renderFnStore.set(function() {
+                return <Component prop2={2} />
+            })
+            expect(computedCalls).toEqual(["prop1: undefined", "prop2: 2"])
+            expect(renders).toBe(1)
+        })
+
+        it("remove all", async () => {
+            renderFnStore.set(function() {
+                return <Component />
+            })
+            expect(computedCalls).toEqual(["prop2: undefined"])
+            expect(renders).toBe(1)
+        })
+
+        let dp = mobx.observable({})
+
+        it("(obs object) deep prop with empty object", async () => {
+            renderFnStore.set(function() {
+                return <Component prop3={dp} />
+            })
+            expect(computedCalls).toEqual(["prop3.x: undefined"])
+            expect(renders).toBe(1)
+        })
+
+        it("(obs object) deep prop with value set", async () => {
+            mobx.set(dp, "x", 5)
+            renderFnStore.set(function() {
+                return <Component prop3={dp} />
+            })
+            expect(computedCalls).toEqual(["prop3.x: 5"])
+            expect(renders).toBe(1)
+        })
+
+        it("(obs object) deep prop with value removed", async () => {
+            mobx.remove(dp, "x")
+            renderFnStore.set(function() {
+                return <Component prop3={dp} />
+            })
+            expect(computedCalls).toEqual(["prop3.x: undefined"])
+            expect(renders).toBe(1)
+        })
+
+        it("(new obj) deep prop with empty object", async () => {
+            renderFnStore.set(function() {
+                return <Component prop3={{}} />
+            })
+            expect(computedCalls).toEqual(["prop3.x: undefined"])
+            expect(renders).toBe(1)
+        })
+
+        it("(new obj) deep prop with value set", async () => {
+            renderFnStore.set(function() {
+                return <Component prop3={{ x: 5 }} />
+            })
+            expect(computedCalls).toEqual(["prop3.x: 5"])
+            expect(renders).toBe(1)
+        })
+
+        it("(new obj) deep prop with value removed", async () => {
+            renderFnStore.set(function() {
+                return <Component prop3={{}} />
+            })
+            expect(computedCalls).toEqual(["prop3.x: undefined"])
+            expect(renders).toBe(1)
+        })
+
+        it("passing a component works", async () => {
+            renderFnStore.set(function() {
+                return <Component componentProp={<div>hi</div>} />
+            })
+            expect(computedCalls).toEqual(["prop3.x: undefined", "componentProp: true"])
+            expect(renders).toBe(1)
+        })
+    })
+}

--- a/test/observer.test.js
+++ b/test/observer.test.js
@@ -668,7 +668,6 @@ test("parent / childs render in the right order", done => {
 
     const container = TestUtils.renderIntoDocument(<Parent />)
 
-    debugger
     tryLogout()
     expect(events).toEqual(["parent", "child", "parent"])
     done()
@@ -854,7 +853,6 @@ test("don't use PureComponent", () => {
     console.warn = m => msg.push(m)
 
     try {
-        debugger
         observer(
             class X extends React.PureComponent {
                 return() {

--- a/test/ts/compile-ts.tsx
+++ b/test/ts/compile-ts.tsx
@@ -2,7 +2,15 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 import { Component } from "react"
 import * as PropTypes from "prop-types"
-import { observer, Provider, propTypes, inject, Observer, disposeOnUnmount } from "../../src"
+import {
+    observer,
+    Provider,
+    propTypes,
+    inject,
+    Observer,
+    disposeOnUnmount,
+    observableProps
+} from "../../src"
 import * as createClass from "create-react-class"
 
 @observer
@@ -300,4 +308,14 @@ inject(({ x }) => ({ x }))(InjectSomeStores)
         methodB = disposeOnUnmount(this, () => {})
     }
     */
+}
+
+{
+    class C extends Component<{ x: number }, { y: string }> {
+        obsProps = observableProps(this)
+
+        m() {
+            const x: number = this.obsProps.x
+        }
+    }
 }


### PR DESCRIPTION
### observableProps(componentInstance) _[Requires MobX >= 5]_

Function that converts your props into fully reactive (observable) props.
This allows you to, for example, create reactions/autorun/computed over individual props rather than the whole props object.

```javascript
import { observer, observableProps } from "mobx-react"

<NameAndAge first="Mary" last="Poppins" age={30} />

@observer
class NameAndAge extends React.Component {
    obsProps = observableProps(this)

    @computed
    get fullName() {
        // this computed will only recompute when any of these props change
        // if we were using props instead it would also recompute if age
        // (or any other property) changed
        return this.obsProps.first + " " + this.obsProps.last;
    }
}
```

A non breaking change since it is opt-in
requires mobx5 since it requires the proxy to detect when props is adding a new property, will throw if that capability is not present (this is, mobx <= 4)