### PR TITLE
Create a failing test for React.forwardRef

### DIFF
--- a/test/stateless.test.js
+++ b/test/stateless.test.js
@@ -74,3 +74,19 @@ test("component with observable propTypes", () => {
     expect(warnings.length).toBe(1)
     console.error = originalConsoleError
 })
+
+
+describe("stateless component with forwardRef", () => {
+    const ForwardRefCompObserver = observer(React.forwardRef(
+        ({ testProp }, ref) => <div>result: {testProp}, { ref ? 'got ref' : 'no ref' }</div>
+    ));
+
+    test("render test correct", () => {
+        const component = TestUtils.renderIntoDocument(
+            <ForwardRefCompObserver testProp="hello world" ref={React.createRef()} />
+        )
+        expect(TestUtils.findRenderedDOMComponentWithTag(component, "div").innerHTML).toBe(
+            "result: hello world, got ref"
+        )
+    })
+})


### PR DESCRIPTION
This is a failing test to illustrate https://github.com/mobxjs/mobx-react/issues/602. It fails with:

```
Error: Uncaught [TypeError: Cannot read property 'displayName' of undefined]
```

I'm pretty confident that this should work, and that this is the underlying issue that breaks styled components: any components that use [ref forwarding](https://reactjs.org/docs/forwarding-refs.html) can't be passed to `observe()`.