### PR TITLE
TypeScript, MobX-React, and RefObjects

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -1,4 +1,4 @@
-import { Component, createElement } from "react"
+import React, { Component, createElement } from "react"
 import hoistStatics from "hoist-non-react-statics"
 import * as PropTypes from "./propTypes"
 import { observer } from "./observer"
@@ -113,7 +113,7 @@ export default function inject(/* fn(stores, nextProps) or ...storeNames */) {
                 // see #111
                 injected = observer(injected)
                 injected.isMobxInjector = true // restore warning
-                return injected
+                return createElement(injected, props)
             })
 
         }
@@ -123,7 +123,9 @@ export default function inject(/* fn(stores, nextProps) or ...storeNames */) {
         grabStoresFn = grabStoresByName(storeNames)
         return function(componentClass) {
             return React.forwardRef((props, ref) => {
-                return createStoreInjector(grabStoresFn, componentClass, ref, storeNames.join("-"))
+                return createElement(
+                    createStoreInjector(grabStoresFn, componentClass, ref, storeNames.join("-")),
+                    props)
             })
         }
     }

--- a/src/inject.js
+++ b/src/inject.js
@@ -137,7 +137,7 @@ export default function inject(/* fn(stores, nextProps) or ...storeNames */) {
 
             let forwardRef =  React.forwardRef((props, ref) => {
                 return createElement(
-                    createStoreInjector(grabStoresFn, component, ref,),
+                    createStoreInjector(grabStoresFn, component, ref),
                     props)
             })
             

--- a/src/inject.js
+++ b/src/inject.js
@@ -103,13 +103,8 @@ export default function inject(/* fn(stores, nextProps) or ...storeNames */) {
 
             let forwardRef =  React.forwardRef((props, ref) => {
                 let injected = createStoreInjector(grabStoresFn, component, ref)
-                injected.isMobxInjector = false // supress warning
-                // mark the Injector as observer, to make it react to expressions in `grabStoresFn`,
-                // see #111
-                injected = observer(injected)
-                injected.isMobxInjector = true // restore warning
 
-                return createElement(injected, props).render;
+                return createElement(injected, props)
             })
 
             // Static fields from component should be visible on the generated Injector

--- a/src/inject.js
+++ b/src/inject.js
@@ -103,8 +103,13 @@ export default function inject(/* fn(stores, nextProps) or ...storeNames */) {
 
             let forwardRef =  React.forwardRef((props, ref) => {
                 let injected = createStoreInjector(grabStoresFn, component, ref)
+                injected.isMobxInjector = false // supress warning
+                // mark the Injector as observer, to make it react to expressions in `grabStoresFn`,
+                // see #111
+                injected = observer(injected)
+                injected.isMobxInjector = true // restore warning
 
-                return createElement(injected, props)
+                return createElement(injected, props).render;
             })
 
             // Static fields from component should be visible on the generated Injector

--- a/src/inject.js
+++ b/src/inject.js
@@ -124,7 +124,7 @@ export default function inject(/* fn(stores, nextProps) or ...storeNames */) {
         return function(componentClass) {
             return React.forwardRef((props, ref) => {
                 return createStoreInjector(grabStoresFn, componentClass, ref, storeNames.join("-"))
-            }
+            })
         }
     }
 }

--- a/src/inject.js
+++ b/src/inject.js
@@ -103,6 +103,11 @@ export default function inject(/* fn(stores, nextProps) or ...storeNames */) {
 
             let forwardRef =  React.forwardRef((props, ref) => {
                 let injected = createStoreInjector(grabStoresFn, component, ref)
+                injected.isMobxInjector = false // supress warning
+                // mark the Injector as observer, to make it react to expressions in `grabStoresFn`,
+                // see #111
+                injected = observer(injected)
+                injected.isMobxInjector = true // restore warning
 
                 return createElement(injected, props)
             })

--- a/src/inject.js
+++ b/src/inject.js
@@ -71,6 +71,7 @@ function createStoreInjector(grabStoresFn, component, forwardedRef, injectNames)
     // Static fields from component should be visible on the generated Injector
     hoistStatics(Injector, component)
 
+    Injector.wrappedComponent = component
     Object.defineProperties(Injector, proxiedInjectorProps)
 
     return Injector

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -244,6 +244,8 @@ describe("inject based context", () => {
         expect(C.bla).toBe(17)
         expect(C.bla2 === B.bla2).toBeTruthy()
         expect(Object.keys(C.wrappedComponent.propTypes)).toEqual(["x"])
+
+        mount(<div><C ref={ref => expect(ref.testField).toBe(1)} booh={42} /></div>)
     })
 
     test("warning is printed when attaching contextTypes to HOC", () => {

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -244,10 +244,6 @@ describe("inject based context", () => {
         expect(C.bla).toBe(17)
         expect(C.bla2 === B.bla2).toBeTruthy()
         expect(Object.keys(C.wrappedComponent.propTypes)).toEqual(["x"])
-
-        const wrapper = mount(<C booh={42} />)
-        await sleepHelper(10)
-        expect(wrapper.instance().wrappedInstance.testField).toBe(1)
     })
 
     test("warning is printed when attaching contextTypes to HOC", () => {


### PR DESCRIPTION
Fixed issue where inject decorated classes were not compatible with strongly typed RefObjects