### PR TITLE
Cache newSymbol created Symbols

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -5,13 +5,21 @@ export function isStateless(component) {
 }
 
 let symbolId = 0
-export function newSymbol(name) {
+function createSymbol(name) {
     if (typeof Symbol === "function") {
         return Symbol(name)
     }
     const symbol = `__$mobx-react ${name} (${symbolId})`
     symbolId++
     return symbol
+}
+
+const createdSymbols = {}
+export function newSymbol(name) {
+    if (!createdSymbols[name]) {
+        createdSymbols[name] = createSymbol(name)
+    }
+    return createdSymbols[name]
 }
 
 const mobxMixins = newSymbol("patchMixins")

--- a/test/symbol.test.js
+++ b/test/symbol.test.js
@@ -3,6 +3,7 @@ delete global.Symbol
 import React, { Component } from "react"
 import { observer } from "../src"
 import { asyncReactDOMRender, createTestRoot } from "./"
+import { newSymbol } from "../src/utils/utils"
 
 const testRoot = createTestRoot()
 
@@ -15,4 +16,11 @@ test("work without Symbol", async () => {
         }
     )
     await asyncReactDOMRender(<Component1 />, testRoot)
+})
+
+test("cache newSymbol created Symbols", () => {
+    const symbol1 = newSymbol("name")
+    const symbol2 = newSymbol("name")
+
+    expect(symbol1).toEqual(symbol2)
 })


### PR DESCRIPTION
The observer decorator created 2 Symbols for each decorated component
instead of reusing the Symbols for props and state that was previously
created