### PR TITLE
Adds Ignite Bowser boilerplate to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you are using [React hooks](https://reactjs.org/docs/hooks-intro.html) with l
 *   Minimal MobX, React, ES6(babel), JSPM with hot reloading modules:
     [jspm-react](https://github.com/capaj/jspm-react)
 *   React Native Counter: [Mobx-React-Native-Counter](https://github.com/bartonhammond/mobx-react-native-counter)
+*   React Native, TypeScript, React Navigation: [Ignite Bowser](https://github.com/infinitered/ignite-bowser)
 
 ## API documentation
 


### PR DESCRIPTION
Adds [Ignite Bowser](https://github.com/infinitered/ignite-bowser) boilerplate which uses MobX-React.