### PR TITLE
Separates decorator/instance usage of disposeOnUnmount

### DIFF
--- a/src/disposeOnUnmount.js
+++ b/src/disposeOnUnmount.js
@@ -1,14 +1,11 @@
 import * as React from "react"
 import { patch, newSymbol } from "./utils/utils"
 
-const storeKey = newSymbol("disposeOnUnmount")
+const protoStoreKey = newSymbol("disposeOnUnmountProto")
+const instStoreKey = newSymbol("disposeOnUnmountInst")
 
 function runDisposersOnWillUnmount() {
-    if (!this[storeKey]) {
-        // when disposeOnUnmount is only set to some instances of a component it will still patch the prototype
-        return
-    }
-    this[storeKey].forEach(propKeyOrFunction => {
+    ;[...(this[protoStoreKey] || []), ...(this[instStoreKey] || [])].forEach(propKeyOrFunction => {
         const prop =
             typeof propKeyOrFunction === "string" ? this[propKeyOrFunction] : propKeyOrFunction
         if (prop !== undefined && prop !== null) {
@@ -20,7 +17,6 @@ function runDisposersOnWillUnmount() {
             prop()
         }
     })
-    this[storeKey] = []
 }
 
 export function disposeOnUnmount(target, propertyKeyOrFunction) {
@@ -38,9 +34,16 @@ export function disposeOnUnmount(target, propertyKeyOrFunction) {
         )
     }
 
+    // decorator's target is the prototype, so it doesn't have any instance properties like props
+    const isDecorator = !target.hasOwnProperty("props")
+
     // add property key / function we want run (disposed) to the store
-    const componentWasAlreadyModified = !!target[storeKey]
-    const store = target[storeKey] || (target[storeKey] = [])
+    const componentWasAlreadyModified = !!target[protoStoreKey] || !!target[instStoreKey]
+    const store = isDecorator
+        ? // decorators are added to the prototype store
+          target[protoStoreKey] || (target[protoStoreKey] = [])
+        : // functions are added to the instance store
+          target[instStoreKey] || (target[instStoreKey] = [])
 
     store.push(propertyKeyOrFunction)
 

--- a/test/disposeOnUnmount.test.js
+++ b/test/disposeOnUnmount.test.js
@@ -503,3 +503,36 @@ it("componentDidMount should be different between components", async () => {
     await doTest(true)
     await doTest(false)
 })
+
+it.only("runDisposersOnUnmount only runs disposers from the declaring instance", async () => {
+    class A extends React.Component {
+        @disposeOnUnmount
+        a = jest.fn()
+
+        b = jest.fn()
+
+        constructor() {
+            super()
+            disposeOnUnmount(this, this.b)
+        }
+
+        render() {
+            return null
+        }
+    }
+
+    const testRoot2 = createTestRoot()
+
+    const ref1 = React.createRef()
+    const ref2 = React.createRef()
+    await asyncReactDOMRender(<A ref={ref1} />, testRoot)
+    await asyncReactDOMRender(<A ref={ref2} />, testRoot2)
+    const inst1 = ref1.current
+    const inst2 = ref2.current
+    await asyncReactDOMRender(null, testRoot)
+
+    expect(inst1.a).toHaveBeenCalledTimes(1)
+    expect(inst1.b).toHaveBeenCalledTimes(1)
+    expect(inst2.a).toHaveBeenCalledTimes(0)
+    expect(inst2.b).toHaveBeenCalledTimes(0)
+})


### PR DESCRIPTION
Fixes #666 by splitting the disposer store into two separate prototype and instance stores, depending on the target parameter.