### PR TITLE
Fix Object.keys with ES6 syntax as props

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -66,9 +66,14 @@ const hoistBlackList = {
 }
 
 export function copyStaticProperties(base, target) {
-    Object.keys(base).forEach(key => {
-        if (base.hasOwnProperty(key) && !hoistBlackList[key]) {
-            Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(base, key))
-        }
-    })
+    const protoProps = Object.getOwnPropertyNames(Object.getPrototypeOf(base));
+    Object.getOwnPropertyNames(base).forEach(key => {
+      if (!hoistBlackList[key] && !protoProps.includes(key)) {
+        Object.defineProperty(
+          target,
+          key,
+          Object.getOwnPropertyDescriptor(base, key)
+        );
+      }
+    });
 }


### PR DESCRIPTION
- Changed .keys to .getOwnPropertyNames - This gets inherited or prototype properties such as "length, prototype,..."
- Filter properties that are inherited prototypes .getPrototypeOf
- Then copy the needed keys to target

- Fixes #678 
- Example on codesandbox here https://codesandbox.io/embed/kind-gauss-pfv5q