### PR TITLE
Restored mixin based implementation of `observer` for class based components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # MobX-React Changelog
 
+### 6.1.0
+
+-   Restored the classic implementation of `observer`: class based components are patched again, rather than wrapping them in `<Observer>`, see [#703](https://github.com/mobxjs/mobx-react/pull/703). Fixes:
+    -   `componentDidUpdate` not being triggered after a reactive render [#692](https://github.com/mobxjs/mobx-react/issues/692)
+    -   The appearance of an additional `<Observer>` component in the component tree, which complicates shallow testing [#699](https://github.com/mobxjs/mobx-react/issues/699)
+    -   Some regressions in `disposeOnUnmount` [#702](https://github.com/mobxjs/mobx-react/issues/702)
+    -   Note that dev tool support, and other constraints mentioned in the 6.0.0 release notes have not been restored.
+-   The function `useStaticRendering(value: boolean): void` from mobx-react-lite is now exposed
+
 ### 6.0.4
 
 -   Fixed IE 11 compatibility which was accidentally broken. Fixes [#698](https://github.com/mobxjs/mobx-react/issues/698)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -75,6 +75,7 @@ export class Provider extends React.Component<any, {}> {}
 export const MobXProviderContext: React.Context<any>
 
 export function useStaticRendering(value: boolean): void
+export function isUsingStaticRendering(): boolean
 
 export const PropTypes: {
     observableArray: React.Requireable<any>

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,11 @@ export {
     Observer,
     useAsObservableSource,
     useLocalStore,
-    isUsingStaticRendering
+    isUsingStaticRendering,
+    useStaticRendering
 } from "mobx-react-lite"
 
 export { observer } from "./observer"
-export { useStaticRendering } from "./observerClass"
 
 export { Provider, MobXProviderContext } from "./Provider"
 export { inject } from "./inject"

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,12 @@ if (!observable) throw new Error("mobx-react requires mobx to be available")
 
 if (typeof rdBatched === "function") configure({ reactionScheduler: rdBatched })
 
-export { Observer, useAsObservableSource, useLocalStore } from "mobx-react-lite"
+export {
+    Observer,
+    useAsObservableSource,
+    useLocalStore,
+    isUsingStaticRendering
+} from "mobx-react-lite"
 
 export { observer } from "./observer"
 export { useStaticRendering } from "./observerClass"

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ if (typeof rdBatched === "function") configure({ reactionScheduler: rdBatched })
 
 export { Observer, useAsObservableSource, useLocalStore } from "mobx-react-lite"
 
-export { observer, useStaticRendering } from "./observer"
+export { observer } from "./observer"
+export { useStaticRendering } from "./observerClass"
 
 export { Provider, MobXProviderContext } from "./Provider"
 export { inject } from "./inject"

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,91 +1,12 @@
-import React, { Component, PureComponent, forwardRef } from "react"
-import { createAtom, _allowStateChanges } from "mobx"
-import {
-    observer as observerLite,
-    useStaticRendering as useStaticRenderingLite,
-    Observer
-} from "mobx-react-lite"
+import React, { Component, forwardRef } from "react"
+import { _allowStateChanges } from "mobx"
+import { observer as observerLite, Observer } from "mobx-react-lite"
 
-import { newSymbol, shallowEqual } from "./utils/utils"
-
-let isUsingStaticRendering = false
-
-const skipRenderKey = newSymbol("skipRender")
-const isForcingUpdateKey = newSymbol("isForcingUpdate")
+import { makeClassComponentObserver } from "./observerClass"
 
 // Using react-is had some issues (and operates on elements, not on types), see #608 / #609
 const ReactForwardRefSymbol =
     typeof forwardRef === "function" && forwardRef((_props, _ref) => {})["$$typeof"]
-
-/**
- * Helper to set `prop` to `this` as non-enumerable (hidden prop)
- * @param target
- * @param prop
- * @param value
- */
-function setHiddenProp(target, prop, value) {
-    if (!Object.hasOwnProperty.call(target, prop)) {
-        Object.defineProperty(target, prop, {
-            enumerable: false,
-            configurable: true,
-            writable: true,
-            value
-        })
-    } else {
-        target[prop] = value
-    }
-}
-
-export function useStaticRendering(useStaticRendering) {
-    isUsingStaticRendering = useStaticRendering
-    useStaticRenderingLite(useStaticRendering)
-}
-
-function observerSCU(nextProps, nextState) {
-    if (isUsingStaticRendering) {
-        console.warn(
-            "[mobx-react] It seems that a re-rendering of a React component is triggered while in static (server-side) mode. Please make sure components are rendered only once server-side."
-        )
-    }
-    // update on any state changes (as is the default)
-    if (this.state !== nextState) {
-        return true
-    }
-    // update if props are shallowly not equal, inspired by PureRenderMixin
-    // we could return just 'false' here, and avoid the `skipRender` checks etc
-    // however, it is nicer if lifecycle events are triggered like usually,
-    // so we return true here if props are shallowly modified.
-    return !shallowEqual(this.props, nextProps)
-}
-
-function makeObservableProp(target, propName) {
-    const valueHolderKey = newSymbol(`reactProp_${propName}_valueHolder`)
-    const atomHolderKey = newSymbol(`reactProp_${propName}_atomHolder`)
-    function getAtom() {
-        if (!this[atomHolderKey]) {
-            setHiddenProp(this, atomHolderKey, createAtom("reactive " + propName))
-        }
-        return this[atomHolderKey]
-    }
-    Object.defineProperty(target, propName, {
-        configurable: true,
-        enumerable: true,
-        get: function() {
-            getAtom.call(this).reportObserved()
-            return this[valueHolderKey]
-        },
-        set: function set(v) {
-            if (!this[isForcingUpdateKey] && !shallowEqual(this[valueHolderKey], v)) {
-                setHiddenProp(this, valueHolderKey, v)
-                setHiddenProp(this, skipRenderKey, true)
-                getAtom.call(this).reportChanged()
-                setHiddenProp(this, skipRenderKey, false)
-            } else {
-                setHiddenProp(this, valueHolderKey, v)
-            }
-        }
-    })
-}
 
 /**
  * Observer function / decorator
@@ -120,30 +41,4 @@ export function observer(componentClass) {
     }
 
     return makeClassComponentObserver(componentClass)
-}
-
-function makeClassComponentObserver(componentClass) {
-    const target = componentClass.prototype || componentClass
-    if (target.componentWillReact)
-        throw new Error("The componentWillReact life-cycle event is no longer supported")
-    if (componentClass.__proto__ !== PureComponent) {
-        if (!target.shouldComponentUpdate) target.shouldComponentUpdate = observerSCU
-        else if (target.shouldComponentUpdate !== observerSCU)
-            throw new Error(
-                "It is not allowed to use shouldComponentUpdate in observer based components."
-            )
-    }
-    makeObservableProp(target, "props")
-    makeObservableProp(target, "state")
-    const baseRender = target.render
-
-    target.render = function renderWrapper() {
-        if (!this.baseRender) {
-            // safe the closure, as it won't change!
-            const bound = baseRender.bind(this)
-            this.baseRender = () => bound()
-        }
-        return <Observer>{this.baseRender}</Observer>
-    }
-    return componentClass
 }

--- a/src/observerClass.js
+++ b/src/observerClass.js
@@ -1,0 +1,161 @@
+import { PureComponent, Component } from "react"
+import { createAtom, _allowStateChanges, Reaction, $mobx } from "mobx"
+import { useStaticRendering as useStaticRenderingLite } from "mobx-react-lite"
+
+import { newSymbol, shallowEqual, setHiddenProp } from "./utils/utils"
+
+let isUsingStaticRendering = false
+
+const mobxAdminProperty = $mobx || "$mobx"
+const mobxIsUnmounted = newSymbol("isUnmounted")
+const skipRenderKey = newSymbol("skipRender")
+const isForcingUpdateKey = newSymbol("isForcingUpdate")
+
+export function useStaticRendering(useStaticRendering) {
+    isUsingStaticRendering = useStaticRendering
+    useStaticRenderingLite(useStaticRendering)
+}
+
+export function makeClassComponentObserver(componentClass) {
+    const target = componentClass.prototype || componentClass
+    if (target.componentWillReact)
+        throw new Error("The componentWillReact life-cycle event is no longer supported")
+    if (componentClass.__proto__ !== PureComponent) {
+        if (!target.shouldComponentUpdate) target.shouldComponentUpdate = observerSCU
+        else if (target.shouldComponentUpdate !== observerSCU)
+            throw new Error(
+                "It is not allowed to use shouldComponentUpdate in observer based components."
+            )
+    }
+
+    makeObservableProp(target, "props")
+    makeObservableProp(target, "state")
+    const baseRender = target.render
+    target.render = function() {
+        return makeComponentReactive.call(this, baseRender)
+    }
+    const baseWillUnmount = target.componentWillUnmount
+    target.componentWillUnmount = function() {
+        if (isUsingStaticRendering === true) return
+        this.render[mobxAdminProperty] && this.render[mobxAdminProperty].dispose()
+        this[mobxIsUnmounted] = true
+        if (baseWillUnmount) baseWillUnmount.call(this)
+    }
+    return componentClass
+}
+
+function makeComponentReactive(render) {
+    if (isUsingStaticRendering === true) return render.call(this)
+
+    function reactiveRender() {
+        isRenderingPending = false
+        let exception = undefined
+        let rendering = undefined
+        reaction.track(() => {
+            try {
+                rendering = _allowStateChanges(false, baseRender)
+            } catch (e) {
+                exception = e
+            }
+        })
+        if (exception) {
+            throw exception
+        }
+        return rendering
+    }
+
+    // Generate friendly name for debugging
+    const initialName =
+        this.displayName ||
+        this.name ||
+        (this.constructor && (this.constructor.displayName || this.constructor.name)) ||
+        "<component>"
+    /**
+     * If props are shallowly modified, react will render anyway,
+     * so atom.reportChanged() should not result in yet another re-render
+     */
+    setHiddenProp(this, skipRenderKey, false)
+    /**
+     * forceUpdate will re-assign this.props. We don't want that to cause a loop,
+     * so detect these changes
+     */
+    setHiddenProp(this, isForcingUpdateKey, false)
+
+    // wire up reactive render
+    const baseRender = render.bind(this)
+    let isRenderingPending = false
+
+    const reaction = new Reaction(`${initialName}.render()`, () => {
+        if (!isRenderingPending) {
+            // N.B. Getting here *before mounting* means that a component constructor has side effects (see the relevant test in misc.js)
+            // This unidiomatic React usage but React will correctly warn about this so we continue as usual
+            // See #85 / Pull #44
+            isRenderingPending = true
+            if (typeof this.componentWillReact === "function") this.componentWillReact() // TODO: wrap in action?
+            if (this[mobxIsUnmounted] !== true) {
+                // If we are unmounted at this point, componentWillReact() had a side effect causing the component to unmounted
+                // TODO: remove this check? Then react will properly warn about the fact that this should not happen? See #73
+                // However, people also claim this might happen during unit tests..
+                let hasError = true
+                try {
+                    setHiddenProp(this, isForcingUpdateKey, true)
+                    if (!this[skipRenderKey]) Component.prototype.forceUpdate.call(this)
+                    hasError = false
+                } finally {
+                    setHiddenProp(this, isForcingUpdateKey, false)
+                    if (hasError) reaction.dispose()
+                }
+            }
+        }
+    })
+    reaction.reactComponent = this
+    reactiveRender[mobxAdminProperty] = reaction
+    this.render = reactiveRender
+    return reactiveRender.call(this)
+}
+
+function observerSCU(nextProps, nextState) {
+    if (isUsingStaticRendering) {
+        console.warn(
+            "[mobx-react] It seems that a re-rendering of a React component is triggered while in static (server-side) mode. Please make sure components are rendered only once server-side."
+        )
+    }
+    // update on any state changes (as is the default)
+    if (this.state !== nextState) {
+        return true
+    }
+    // update if props are shallowly not equal, inspired by PureRenderMixin
+    // we could return just 'false' here, and avoid the `skipRender` checks etc
+    // however, it is nicer if lifecycle events are triggered like usually,
+    // so we return true here if props are shallowly modified.
+    return !shallowEqual(this.props, nextProps)
+}
+
+function makeObservableProp(target, propName) {
+    const valueHolderKey = newSymbol(`reactProp_${propName}_valueHolder`)
+    const atomHolderKey = newSymbol(`reactProp_${propName}_atomHolder`)
+    function getAtom() {
+        if (!this[atomHolderKey]) {
+            setHiddenProp(this, atomHolderKey, createAtom("reactive " + propName))
+        }
+        return this[atomHolderKey]
+    }
+    Object.defineProperty(target, propName, {
+        configurable: true,
+        enumerable: true,
+        get: function() {
+            getAtom.call(this).reportObserved()
+            return this[valueHolderKey]
+        },
+        set: function set(v) {
+            if (!this[isForcingUpdateKey] && !shallowEqual(this[valueHolderKey], v)) {
+                setHiddenProp(this, valueHolderKey, v)
+                setHiddenProp(this, skipRenderKey, true)
+                getAtom.call(this).reportChanged()
+                setHiddenProp(this, skipRenderKey, false)
+            } else {
+                setHiddenProp(this, valueHolderKey, v)
+            }
+        }
+    })
+}

--- a/src/observerClass.js
+++ b/src/observerClass.js
@@ -1,10 +1,11 @@
 import { PureComponent, Component } from "react"
 import { createAtom, _allowStateChanges, Reaction, $mobx } from "mobx"
-import { useStaticRendering as useStaticRenderingLite } from "mobx-react-lite"
+import {
+    useStaticRendering as useStaticRenderingLite,
+    isUsingStaticRendering
+} from "mobx-react-lite"
 
 import { newSymbol, shallowEqual, setHiddenProp, patch } from "./utils/utils"
-
-let isUsingStaticRendering = false
 
 const mobxAdminProperty = $mobx || "$mobx"
 const mobxIsUnmounted = newSymbol("isUnmounted")
@@ -12,7 +13,6 @@ const skipRenderKey = newSymbol("skipRender")
 const isForcingUpdateKey = newSymbol("isForcingUpdate")
 
 export function useStaticRendering(useStaticRendering) {
-    isUsingStaticRendering = useStaticRendering
     useStaticRenderingLite(useStaticRendering)
 }
 
@@ -41,7 +41,7 @@ export function makeClassComponentObserver(componentClass) {
         return makeComponentReactive.call(this, baseRender)
     }
     patch(target, "componentWillUnmount", function() {
-        if (isUsingStaticRendering === true) return
+        if (isUsingStaticRendering() === true) return
         this.render[mobxAdminProperty] && this.render[mobxAdminProperty].dispose()
         this[mobxIsUnmounted] = true
     })
@@ -49,7 +49,7 @@ export function makeClassComponentObserver(componentClass) {
 }
 
 function makeComponentReactive(render) {
-    if (isUsingStaticRendering === true) return render.call(this)
+    if (isUsingStaticRendering() === true) return render.call(this)
 
     function reactiveRender() {
         isRenderingPending = false
@@ -115,7 +115,7 @@ function makeComponentReactive(render) {
 }
 
 function observerSCU(nextProps, nextState) {
-    if (isUsingStaticRendering) {
+    if (isUsingStaticRendering()) {
         console.warn(
             "[mobx-react] It seems that a re-rendering of a React component is triggered while in static (server-side) mode. Please make sure components are rendered only once server-side."
         )

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -92,3 +92,96 @@ export function setHiddenProp(target, prop, value) {
         target[prop] = value
     }
 }
+
+/**
+ * Utilities for patching componentWillUnmount, to make sure @disposeOnUnmount works correctly icm with user defined hooks
+ * and the handler provided by mobx-react
+ */
+const mobxMixins = newSymbol("patchMixins")
+const mobxPatchedDefinition = newSymbol("patchedDefinition")
+
+function getMixins(target, methodName) {
+    const mixins = (target[mobxMixins] = target[mobxMixins] || {})
+    const methodMixins = (mixins[methodName] = mixins[methodName] || {})
+    methodMixins.locks = methodMixins.locks || 0
+    methodMixins.methods = methodMixins.methods || []
+    return methodMixins
+}
+
+function wrapper(realMethod, mixins, ...args) {
+    // locks are used to ensure that mixins are invoked only once per invocation, even on recursive calls
+    mixins.locks++
+
+    try {
+        let retVal
+        if (realMethod !== undefined && realMethod !== null) {
+            retVal = realMethod.apply(this, args)
+        }
+
+        return retVal
+    } finally {
+        mixins.locks--
+        if (mixins.locks === 0) {
+            mixins.methods.forEach(mx => {
+                mx.apply(this, args)
+            })
+        }
+    }
+}
+
+function wrapFunction(realMethod, mixins) {
+    const fn = function(...args) {
+        wrapper.call(this, realMethod, mixins, ...args)
+    }
+    return fn
+}
+
+export function patch(target, methodName, mixinMethod) {
+    const mixins = getMixins(target, methodName)
+
+    if (mixins.methods.indexOf(mixinMethod) < 0) {
+        mixins.methods.push(mixinMethod)
+    }
+
+    const oldDefinition = Object.getOwnPropertyDescriptor(target, methodName)
+    if (oldDefinition && oldDefinition[mobxPatchedDefinition]) {
+        // already patched definition, do not repatch
+        return
+    }
+
+    const originalMethod = target[methodName]
+    const newDefinition = createDefinition(
+        target,
+        methodName,
+        oldDefinition ? oldDefinition.enumerable : undefined,
+        mixins,
+        originalMethod
+    )
+
+    Object.defineProperty(target, methodName, newDefinition)
+}
+
+function createDefinition(target, methodName, enumerable, mixins, originalMethod) {
+    let wrappedFunc = wrapFunction(originalMethod, mixins)
+
+    return {
+        [mobxPatchedDefinition]: true,
+        get: function() {
+            return wrappedFunc
+        },
+        set: function(value) {
+            if (this === target) {
+                wrappedFunc = wrapFunction(value, mixins)
+            } else {
+                // when it is an instance of the prototype/a child prototype patch that particular case again separately
+                // since we need to store separate values depending on wether it is the actual instance, the prototype, etc
+                // e.g. the method for super might not be the same as the method for the prototype which might be not the same
+                // as the method for the instance
+                const newDefinition = createDefinition(this, methodName, enumerable, mixins, value)
+                Object.defineProperty(this, methodName, newDefinition)
+            }
+        },
+        configurable: true,
+        enumerable: enumerable
+    }
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -73,3 +73,22 @@ export function copyStaticProperties(base, target) {
         }
     })
 }
+
+/**
+ * Helper to set `prop` to `this` as non-enumerable (hidden prop)
+ * @param target
+ * @param prop
+ * @param value
+ */
+export function setHiddenProp(target, prop, value) {
+    if (!Object.hasOwnProperty.call(target, prop)) {
+        Object.defineProperty(target, prop, {
+            enumerable: false,
+            configurable: true,
+            writable: true,
+            value
+        })
+    } else {
+        target[prop] = value
+    }
+}

--- a/test/__snapshots__/inject.test.js.snap
+++ b/test/__snapshots__/inject.test.js.snap
@@ -4,12 +4,12 @@ exports[`inject based context warning is printed when changing stores 2`] = `
 Array [
   Array [
     "The above error occurred in the <Provider> component:",
-    "    in Provider (created by Observer)",
-    "    in section (created by Observer)",
-    "    in Observer",
+    "    in Provider",
+    "    in section",
     "    in Unknown",
     "",
     "Consider adding an error boundary to your tree to customize error handling behavior.",
+    "Visit https://fb.me/react-error-boundaries to learn more about error boundaries.",
   ],
 ]
 `;

--- a/test/__snapshots__/observer.test.js.snap
+++ b/test/__snapshots__/observer.test.js.snap
@@ -27,7 +27,6 @@ Array [
   "Error: Hello",
   Object {
     "componentStack": "
-    in Observer (created by X)
     in X
     in div (created by Outer)
     in Outer",

--- a/test/observer.test.js
+++ b/test/observer.test.js
@@ -817,3 +817,33 @@ test("computed properties react to props", async () => {
 
     expect(seen).toEqual(["parent", 0, "parent", 2])
 })
+
+test("#692 - componentDidUpdate is triggered", async () => {
+    let cDUCount = 0
+
+    @observer
+    class Test extends React.Component {
+        @mobx.observable
+        counter = 0
+
+        @mobx.action
+        inc = () => this.counter++
+
+        componentWillMount() {
+            setTimeout(() => this.inc(), 300)
+        }
+
+        render() {
+            return <p>{this.counter}</p>
+        }
+
+        componentDidUpdate() {
+            cDUCount++
+        }
+    }
+    TestUtils.renderIntoDocument(<Test />)
+    expect(cDUCount).toBe(0)
+
+    await sleepHelper(500)
+    expect(cDUCount).toBe(1)
+})

--- a/test/observer.test.js
+++ b/test/observer.test.js
@@ -501,7 +501,7 @@ test("it rerenders correctly if some props are non-observables - 1", () => {
 
     const wrapper = renderer.create(<Parent odata={odata} data={data} />)
 
-    const contents = () => wrapper.toTree().rendered.rendered.rendered.rendered.rendered.join("")
+    const contents = () => wrapper.toTree().rendered.rendered.rendered.join("")
 
     expect(contents()).toEqual("1-1-1")
     stuff()
@@ -549,7 +549,7 @@ test("it rerenders correctly if some props are non-observables - 2", () => {
 
     const wrapper = renderer.create(<Parent odata={odata} />)
 
-    const contents = () => wrapper.toTree().rendered.rendered.rendered.rendered.join("")
+    const contents = () => wrapper.toTree().rendered.rendered.rendered.join("")
 
     expect(renderCount).toBe(1)
     expect(contents()).toBe("1-1")


### PR DESCRIPTION
Proposal to revert to the classic implementation for class based observer components; by monkey patching the prototype rather than wrapping render in `<Observer>`

Fixes / affects #699, #692, #697, #702 