### PR TITLE
[WIP] cleaner disposeOnCleanup implementation

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -93,95 +93,18 @@ export function setHiddenProp(target, prop, value) {
     }
 }
 
-/**
- * Utilities for patching componentWillUnmount, to make sure @disposeOnUnmount works correctly icm with user defined hooks
- * and the handler provided by mobx-react
- */
-const mobxMixins = newSymbol("patchMixins")
-const mobxPatchedDefinition = newSymbol("patchedDefinition")
-
-function getMixins(target, methodName) {
-    const mixins = (target[mobxMixins] = target[mobxMixins] || {})
-    const methodMixins = (mixins[methodName] = mixins[methodName] || {})
-    methodMixins.locks = methodMixins.locks || 0
-    methodMixins.methods = methodMixins.methods || []
-    return methodMixins
-}
-
-function wrapper(realMethod, mixins, ...args) {
-    // locks are used to ensure that mixins are invoked only once per invocation, even on recursive calls
-    mixins.locks++
-
-    try {
-        let retVal
-        if (realMethod !== undefined && realMethod !== null) {
-            retVal = realMethod.apply(this, args)
-        }
-
-        return retVal
-    } finally {
-        mixins.locks--
-        if (mixins.locks === 0) {
-            mixins.methods.forEach(mx => {
-                mx.apply(this, args)
-            })
-        }
-    }
-}
-
-function wrapFunction(realMethod, mixins) {
-    const fn = function(...args) {
-        wrapper.call(this, realMethod, mixins, ...args)
-    }
-    return fn
-}
-
-export function patch(target, methodName, mixinMethod) {
-    const mixins = getMixins(target, methodName)
-
-    if (mixins.methods.indexOf(mixinMethod) < 0) {
-        mixins.methods.push(mixinMethod)
-    }
-
-    const oldDefinition = Object.getOwnPropertyDescriptor(target, methodName)
-    if (oldDefinition && oldDefinition[mobxPatchedDefinition]) {
-        // already patched definition, do not repatch
-        return
-    }
-
-    const originalMethod = target[methodName]
-    const newDefinition = createDefinition(
-        target,
-        methodName,
-        oldDefinition ? oldDefinition.enumerable : undefined,
-        mixins,
-        originalMethod
-    )
-
-    Object.defineProperty(target, methodName, newDefinition)
-}
-
-function createDefinition(target, methodName, enumerable, mixins, originalMethod) {
-    let wrappedFunc = wrapFunction(originalMethod, mixins)
-
-    return {
-        [mobxPatchedDefinition]: true,
-        get: function() {
-            return wrappedFunc
+export function preventWrites(target, prop) {
+    const impl = target[prop]
+    Object.defineProperty(target, prop, {
+        get() {
+            return impl
         },
-        set: function(value) {
-            if (this === target) {
-                wrappedFunc = wrapFunction(value, mixins)
-            } else {
-                // when it is an instance of the prototype/a child prototype patch that particular case again separately
-                // since we need to store separate values depending on wether it is the actual instance, the prototype, etc
-                // e.g. the method for super might not be the same as the method for the prototype which might be not the same
-                // as the method for the instance
-                const newDefinition = createDefinition(this, methodName, enumerable, mixins, value)
-                Object.defineProperty(this, methodName, newDefinition)
-            }
+        set() {
+            throw new Error(
+                `The property '${prop}' should not be assigned or initialized. Did you try to use an arrow function or apply 'observer' to a sub and superclass?`
+            )
         },
         configurable: true,
-        enumerable: enumerable
-    }
+        enumerable: false
+    })
 }

--- a/test/disposeOnUnmount.test.js
+++ b/test/disposeOnUnmount.test.js
@@ -24,123 +24,6 @@ async function testComponent(C, afterMount, afterUnmount) {
     }
 }
 
-describe("without observer", () => {
-    test("class without componentWillUnmount", async () => {
-        class C extends React.Component {
-            @disposeOnUnmount
-            methodA = jest.fn()
-            @disposeOnUnmount
-            methodB = jest.fn()
-            @disposeOnUnmount
-            methodC = null
-            @disposeOnUnmount
-            methodD = undefined
-
-            render() {
-                return null
-            }
-        }
-
-        await testComponent(C)
-    })
-
-    test("class with componentWillUnmount in the prototype", async () => {
-        let called = 0
-
-        class C extends React.Component {
-            @disposeOnUnmount
-            methodA = jest.fn()
-            @disposeOnUnmount
-            methodB = jest.fn()
-            @disposeOnUnmount
-            methodC = null
-            @disposeOnUnmount
-            methodD = undefined
-
-            render() {
-                return null
-            }
-
-            componentWillUnmount() {
-                called++
-            }
-        }
-
-        await testComponent(
-            C,
-            () => {
-                expect(called).toBe(0)
-            },
-            () => {
-                expect(called).toBe(1)
-            }
-        )
-    })
-
-    test("class with componentWillUnmount as an arrow function", async () => {
-        let called = 0
-
-        class C extends React.Component {
-            @disposeOnUnmount
-            methodA = jest.fn()
-            @disposeOnUnmount
-            methodB = jest.fn()
-            @disposeOnUnmount
-            methodC = null
-            @disposeOnUnmount
-            methodD = undefined
-
-            render() {
-                return null
-            }
-
-            componentWillUnmount = () => {
-                called++
-            }
-        }
-
-        await testComponent(
-            C,
-            () => {
-                expect(called).toBe(0)
-            },
-            () => {
-                expect(called).toBe(1)
-            }
-        )
-    })
-
-    test("class without componentWillUnmount using non decorator version", async () => {
-        let methodC = jest.fn()
-        let methodD = jest.fn()
-        class C extends React.Component {
-            render() {
-                return null
-            }
-
-            methodA = disposeOnUnmount(this, jest.fn())
-            methodB = disposeOnUnmount(this, jest.fn())
-
-            constructor(props) {
-                super(props)
-                disposeOnUnmount(this, [methodC, methodD])
-            }
-        }
-
-        await testComponent(
-            C,
-            () => {
-                expect(methodC).not.toHaveBeenCalled()
-                expect(methodD).not.toHaveBeenCalled()
-            },
-            () => {
-                expect(methodC).toHaveBeenCalledTimes(1)
-                expect(methodD).toHaveBeenCalledTimes(1)
-            }
-        )
-    })
-})
-
 describe("with observer", () => {
     test("class without componentWillUnmount", async () => {
         @observer
@@ -181,40 +64,6 @@ describe("with observer", () => {
             }
 
             componentWillUnmount() {
-                called++
-            }
-        }
-
-        await testComponent(
-            C,
-            () => {
-                expect(called).toBe(0)
-            },
-            () => {
-                expect(called).toBe(1)
-            }
-        )
-    })
-
-    test("class with componentWillUnmount as an arrow function", async () => {
-        let called = 0
-
-        @observer
-        class C extends React.Component {
-            @disposeOnUnmount
-            methodA = jest.fn()
-            @disposeOnUnmount
-            methodB = jest.fn()
-            @disposeOnUnmount
-            methodC = null
-            @disposeOnUnmount
-            methodD = undefined
-
-            render() {
-                return null
-            }
-
-            componentWillUnmount = () => {
                 called++
             }
         }
@@ -335,40 +184,6 @@ it("componentDidMount should be different between components", async () => {
 
     await doTest(true)
     await doTest(false)
-})
-
-test("base cWU should not be called if overriden", async () => {
-    let baseCalled = 0
-    let dCalled = 0
-    let oCalled = 0
-
-    class C extends React.Component {
-        componentWillUnmount() {
-            baseCalled++
-        }
-
-        constructor() {
-            super()
-            this.componentWillUnmount = () => {
-                oCalled++
-            }
-        }
-
-        render() {
-            return null
-        }
-
-        @disposeOnUnmount
-        fn() {
-            dCalled++
-        }
-    }
-
-    await asyncReactDOMRender(<C />, testRoot)
-    await asyncReactDOMRender(null, testRoot)
-    expect(dCalled).toBe(1)
-    expect(oCalled).toBe(1)
-    expect(baseCalled).toBe(0)
 })
 
 test("should error on inheritance", async () => {

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -107,23 +107,22 @@ test("testIsComponentReactive", () => {
 })
 
 test("Do not warn about custom shouldComponentUpdate when it is the one provided by ReactiveMixin", () => {
-    expect(
-        withConsole(() => {
-            const A = observer(
-                class A extends React.Component {
-                    render() {
-                        return null
-                    }
+    expect(() => {
+        const A = observer(
+            class A extends React.Component {
+                render() {
+                    return null
                 }
-            )
-
-            observer(
-                class B extends A {
-                    render() {
-                        return null
-                    }
+            }
+        )
+        observer(
+            class B extends A {
+                render() {
+                    return null
                 }
-            )
-        })
-    ).toMatchSnapshot()
+            }
+        )
+    }).toThrowErrorMatchingInlineSnapshot(
+        `"The property 'componentWillUnmount' should not be assigned or initialized. Did you try to use an arrow function or apply 'observer' to a sub and superclass?"`
+    )
 })


### PR DESCRIPTION
Depends on #704, #705 

This PR reimplements disposeOnCleanup. This is a breaking change. Goal: simplify the implementation of dispose on cleanup (as we tried original in v6, before the old implementation of observer was reverted in #703)

This PR changes the rules of the game of disposeOnCleanup a bit:
- Can only be used on `observer` based components
- `observer` cannot be applied multiple times in an inheritance tree (avoids certain edge cases)
- `render` and `componentWillUnmount` will throw if written to (avoids problems where people use an arrow function with field initializer, instead of declaring the method properly on the prototype)
- running disposers is now done as part of the cleanup of `observer`
- This should all simplify the implementation significantly. However, since some constraints are changed, this is a breaking change

Todo:
- [ ] fix / update all tests
- [x] restore applicable tests from v5
- [x] check tests and implementation #671, things might be applicable here from that PR