### PR TITLE
Add the displayName static property to the Provider component

### DIFF
--- a/src/Provider.js
+++ b/src/Provider.js
@@ -7,6 +7,7 @@ export const MobXProviderContext = createContext({})
 
 export class Provider extends Component {
     static contextType = MobXProviderContext
+    static displayName = "MobXProvider"
 
     constructor(props, context) {
         super(props, context)


### PR DESCRIPTION
The `Provider` component has lost its descriptive name in React Dev Tools in the `6.x` version of `mobx-react`:
![Снимок экрана 2019-06-19 в 23 32 13](https://user-images.githubusercontent.com/153412/59799583-468c1200-92ed-11e9-9dbf-f6273e1bfa4e.png)
This PR adds it back:
![Снимок экрана 2019-06-19 в 23 33 55](https://user-images.githubusercontent.com/153412/59799619-599ee200-92ed-11e9-979f-7b36b8a143ea.png)
