### PR TITLE
Replace React.render with ReactDOM.render in READMEs and test names

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class App extends React.Component {
 
 const person = observable({ name: "John" })
 
-React.render(<App person={person} />, document.body)
+ReactDOM.render(<App person={person} />, document.body)
 person.name = "Mike" // will cause the Observer region to re-render
 ```
 
@@ -124,7 +124,7 @@ class App extends React.Component {
 
 const person = observable({ name: "John" })
 
-React.render(<App person={person} />, document.body)
+ReactDOM.render(<App person={person} />, document.body)
 person.name = "Mike" // will cause the Observer region to re-render
 ```
 

--- a/README_v5.md
+++ b/README_v5.md
@@ -106,7 +106,7 @@ class App extends React.Component {
 
 const person = observable({ name: "John" })
 
-React.render(<App person={person} />, document.body)
+ReactDOM.render(<App person={person} />, document.body)
 person.name = "Mike" // will cause the Observer region to re-render
 ```
 
@@ -127,7 +127,7 @@ class App extends React.Component {
 
 const person = observable({ name: "John" })
 
-React.render(<App person={person} />, document.body)
+ReactDOM.render(<App person={person} />, document.body)
 person.name = "Mike" // will cause the Observer region to re-render
 ```
 

--- a/test/transactions.test.js
+++ b/test/transactions.test.js
@@ -43,7 +43,7 @@ test("mobx issue 50", async () => {
     expect(document.getElementById("x").innerHTML).toBe("false,true,true")
 })
 
-test("React.render should respect transaction", async () => {
+test("ReactDOM.render should respect transaction", async () => {
     const testRoot = createTestRoot()
     const a = mobx.observable.box(2)
     const loaded = mobx.observable.box(false)
@@ -69,7 +69,7 @@ test("React.render should respect transaction", async () => {
     testRoot.parentNode.removeChild(testRoot)
 })
 
-test("React.render in transaction should succeed", async () => {
+test("ReactDOM.render in transaction should succeed", async () => {
     const testRoot = createTestRoot()
     const a = mobx.observable.box(2)
     const loaded = mobx.observable.box(false)


### PR DESCRIPTION
React.render was replaced with ReactDOM.render because of https://reactjs.org/blog/2015/10/07/react-v0.14.html#two-packages-react-and-react-dom.