### PR TITLE
Add the displayName static property to the Injector component

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -11,6 +11,7 @@ function createStoreInjector(grabStoresFn, component, injectNames, makeReactive)
 
     class Injector extends Component {
         static contextType = MobXProviderContext
+        static displayName = displayName
 
         render() {
             const { forwardRef, ...props } = this.props


### PR DESCRIPTION
The `Injector` component has lost its descriptive name in React Dev Tools in the 6.x version of mobx-react:
![Снимок экрана 2019-06-20 в 20 55 56](https://user-images.githubusercontent.com/153412/59870548-67f90680-939e-11e9-99e9-c8d5e13c2e1c.png)
This PR adds it back:
![Снимок экрана 2019-06-20 в 20 57 30](https://user-images.githubusercontent.com/153412/59870562-6cbdba80-939e-11e9-85e2-bd4b87e2cdd5.png)

