### PR TITLE
Get rid of the redundant Injector wrapper

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,9 +1,3 @@
-export function isStateless(component) {
-    // `function() {}` has prototype, but `() => {}` doesn't
-    // `() => {}` via Babel has prototype too.
-    return !(component.prototype && component.prototype.render)
-}
-
 let symbolId = 0
 function createSymbol(name) {
     if (typeof Symbol === "function") {

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,10 @@ export function createTestRoot() {
     return testRoot
 }
 
+export function cleanupTestRoot(testRoot) {
+    testRoot.parentNode.removeChild(testRoot)
+}
+
 export function sleepHelper(time) {
     return new Promise(resolve => {
         setTimeout(resolve, time)


### PR DESCRIPTION
This is the proof of concept:
> Hm, looking at that code I actually wonder if that class component needs to be there. Converting a whole thing to a single functional component would yield tree-like.

https://github.com/mobxjs/mobx-react/pull/715#issuecomment-504358745

Tests are green, but I did not check it on a real production codebase.

Fixes #717 too.