### PR TITLE
Configure Stale & Lock bots

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,1 @@
+_extends: mobx

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,1 @@
+_extends mobx

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,1 @@
-_extends mobx
+_extends: mobx


### PR DESCRIPTION
Both Stale and Lock bot uses https://github.com/probot/probot-config. Which means we can utilize extend from mobx repo across other repos.

The only difference is labels (that's a reason for draft PR). So it's either about overriding per repo or what I think is a better way to consolidate labels and have the same ones in each repo. It's going to be somewhat ugly manual legwork, but I think I want to tackle that. Thoughts?

cc @mweststrate @xaviergonz @ItamarShDev 