### PR TITLE
Add the ability to pass multiple children to Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.1.2
 
 -   Add reexport of `useObserver` from `mobx-react-lite` [#734](https://github.com/mobxjs/mobx-react/issues/734)
+-   Add the ability to pass multiple children to Provider
 
 ### 6.1.1
 

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -21,7 +21,7 @@ export class Provider extends Component {
         return createElement(
             MobXProviderContext.Provider,
             { value: this.state },
-            Children.only(this.props.children)
+            this.props.children
         )
     }
 


### PR DESCRIPTION
I think that this is an old restriction when the legacy Context API was used in `Provider`.