### PR TITLE
Simplify the special props handling in the Provider component

### DIFF
--- a/src/Provider.js
+++ b/src/Provider.js
@@ -1,8 +1,6 @@
 import { Children, Component, createContext, createElement } from "react"
 import { shallowEqual } from "./utils/utils"
 
-const specialReactKeys = { children: true, key: true, ref: true }
-
 export const MobXProviderContext = createContext({})
 
 export class Provider extends Component {
@@ -40,10 +38,6 @@ export class Provider extends Component {
 function grabStores(from) {
     const res = {}
     if (!from) return res
-    for (let key in from) if (validStoreName(key)) res[key] = from[key]
+    for (let key in from) if (key !== "children") res[key] = from[key]
     return res
-}
-
-function validStoreName(key) {
-    return !specialReactKeys[key]
 }

--- a/test/Provider.test.js
+++ b/test/Provider.test.js
@@ -1,0 +1,25 @@
+import React from "react"
+import { Provider } from "../src"
+import { render } from "@testing-library/react"
+import { MobXProviderContext } from "../src/Provider"
+
+describe("Provider", () => {
+    it("should not provide the children prop", () => {
+        function A() {
+            return (
+                <Provider>
+                    <MobXProviderContext.Consumer>
+                        {stores =>
+                            stores.hasOwnProperty("children")
+                                ? "children was provided"
+                                : "children was not provided"
+                        }
+                    </MobXProviderContext.Consumer>
+                </Provider>
+            )
+        }
+
+        const { container } = render(<A />)
+        expect(container).toHaveTextContent("children was not provided")
+    })
+})


### PR DESCRIPTION
I think that the special props handling logic in the `Provider` component is partially redundant. `key` and `ref` are special and we do not need to filter them because the props object will never contain them.
> Most props on a JSX element are passed on to the component, however, there are two special props (ref and key) which are used by React, and are thus not forwarded to the component.

https://reactjs.org/warnings/special-props.html