### PR TITLE
Setup missing React act(...) warning workaround globally in tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,8 @@
+// Uglyness to find missing 'act' more easily
+// 14-2-19 / React 16.8.1, temporarily work around, as error message misses a stack-trace
+Error.stackTraceLimit = Infinity
+const origError = console.error
+console.error = function(msg) {
+    if (/react-wrap-tests-with-act/.test("" + msg)) throw new Error("missing act")
+    return origError.apply(this, arguments)
+}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
   "jest": {
     "setupFilesAfterEnv": [
       "@testing-library/react/cleanup-after-each",
-      "@testing-library/jest-dom/extend-expect"
+      "@testing-library/jest-dom/extend-expect",
+      "<rootDir>/jest.setup.js"
     ],
     "testURL": "http://127.0.0.1/"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,3 @@
-// Uglyness to find missing 'act' more easily
-// 14-2-19 / React 16.8.1, temporarily work around, as error message misses a stack-trace
-Error.stackTraceLimit = Infinity
-const origError = console.error
-console.error = function(msg) {
-    if (/react-wrap-tests-with-act/.test("" + msg)) throw new Error("missing act")
-    return origError.apply(this, arguments)
-}
-
 export function withConsole(fn) {
     const { warn, error, info } = global.console
     const warnings = []


### PR DESCRIPTION
The advantage is that we do not need to import `test/index.js` manually in each test.