### PR TITLE
Use the react-testing-library rerender function instead of render to the container

### DIFF
--- a/test/disposeOnUnmount.test.js
+++ b/test/disposeOnUnmount.test.js
@@ -303,7 +303,7 @@ it("componentDidMount should be different between components", () => {
         }
 
         const aRef = React.createRef()
-        const { container, unmount } = render(<A ref={aRef} />)
+        const { rerender, unmount } = render(<A ref={aRef} />)
         const caRef = aRef.current
 
         expect(caRef.didMount).toBe("A")
@@ -311,7 +311,7 @@ it("componentDidMount should be different between components", () => {
         expect(events).toEqual(["mountA"])
 
         const bRef = React.createRef()
-        render(<B ref={bRef} />, { container })
+        rerender(<B ref={bRef} />)
         const cbRef = bRef.current
 
         expect(caRef.didMount).toBe("A")

--- a/test/issue21.test.js
+++ b/test/issue21.test.js
@@ -474,10 +474,10 @@ test("verify props are reactive in componentWillMount and constructor", () => {
         }
     )
 
-    const { container } = render(<Component prop1="1" prop2="4" />)
-    render(<Component prop1="2" prop2="3" />, { container })
-    render(<Component prop1="3" prop2="2" />, { container })
-    render(<Component prop1="4" prop2="1" />, { container })
+    const { rerender } = render(<Component prop1="1" prop2="4" />)
+    rerender(<Component prop1="2" prop2="3" />)
+    rerender(<Component prop1="3" prop2="2" />)
+    rerender(<Component prop1="4" prop2="1" />)
     expect(constructorCallsCount).toEqual(1)
     expect(componentWillMountCallsCount).toEqual(1)
     expect(prop1Values).toEqual(["1", "2", "3", "4"])


### PR DESCRIPTION
This is the small PR with mostly cosmetic changes. I didn't know about this function when I refactored these tests.