### PR TITLE
Do not use deprecated lifecycle methods in tests

### DIFF
--- a/test/issue21.test.js
+++ b/test/issue21.test.js
@@ -145,9 +145,6 @@ test("verify prop changes are picked up", () => {
     const events = []
     const Child = observer(
         class Child extends Component {
-            componentWillReceiveProps(nextProps) {
-                events.push(["receive", this.props.item.subid, nextProps.item.subid])
-            }
             componentDidUpdate(prevProps) {
                 events.push(["update", prevProps.item.subid, this.props.item.subid])
             }
@@ -187,13 +184,7 @@ test("verify prop changes are picked up", () => {
     events.splice(0)
     container.querySelector("#testDiv").click()
     expect(events.sort()).toEqual(
-        [
-            ["compute", 1],
-            ["receive", 1, 2],
-            ["update", 1, 2],
-            ["compute", 2],
-            ["render", 2, "1.2.test.0"]
-        ].sort()
+        [["compute", 1], ["update", 1, 2], ["compute", 2], ["render", 2, "1.2.test.0"]].sort()
     )
 })
 
@@ -238,9 +229,6 @@ test("verify props is reactive", () => {
                         return this.props.item.label
                     }
                 })
-            }
-            componentWillReceiveProps(nextProps) {
-                events.push(["receive", this.props.item.subid, nextProps.item.subid])
             }
             componentDidUpdate(prevProps) {
                 events.push(["update", prevProps.item.subid, this.props.item.subid])
@@ -295,7 +283,6 @@ test("verify props is reactive", () => {
     expect(events.sort()).toEqual(
         [
             ["compute", 1],
-            ["receive", 1, 2],
             ["update", 1, 2],
             ["compute", 2],
             ["computed label", 2],
@@ -325,10 +312,6 @@ test("no re-render for shallow equal props", async () => {
             componentWillMount() {
                 events.push(["mount"])
             }
-            componentWillReceiveProps(nextProps) {
-                events.push(["receive", this.props.item.subid, nextProps.item.subid])
-            }
-
             componentDidUpdate(prevProps) {
                 events.push(["update", prevProps.item.subid, this.props.item.subid])
             }
@@ -367,22 +350,14 @@ test("no re-render for shallow equal props", async () => {
     expect(events.sort()).toEqual([["parent render", 0], ["mount"], ["render", 1, "hi"]].sort())
     events.splice(0)
     container.querySelector("#testDiv").click()
-    expect(events.sort()).toEqual([["parent render", 1], ["receive", 1, 1]].sort())
+    expect(events.sort()).toEqual([["parent render", 1]].sort())
 })
 
 test("lifecycle callbacks called with correct arguments", () => {
     var Comp = observer(
         class Comp extends Component {
-            componentWillReceiveProps(nextProps) {
-                // "componentWillReceiveProps: nextProps.counter === 1"
-                expect(nextProps.counter).toBe(1)
-                // "componentWillReceiveProps: this.props.counter === 1"
-                expect(this.props.counter).toBe(0)
-            }
             componentDidUpdate(prevProps) {
-                // "componentWillReceiveProps: nextProps.counter === 1"
                 expect(prevProps.counter).toBe(0)
-                // "componentWillReceiveProps: this.props.counter === 1"
                 expect(this.props.counter).toBe(1)
             }
             render() {

--- a/test/issue21.test.js
+++ b/test/issue21.test.js
@@ -148,8 +148,8 @@ test("verify prop changes are picked up", () => {
             componentWillReceiveProps(nextProps) {
                 events.push(["receive", this.props.item.subid, nextProps.item.subid])
             }
-            componentWillUpdate(nextProps) {
-                events.push(["update", this.props.item.subid, nextProps.item.subid])
+            componentDidUpdate(prevProps) {
+                events.push(["update", prevProps.item.subid, this.props.item.subid])
             }
             render() {
                 events.push(["render", this.props.item.subid, this.props.item.text])
@@ -242,8 +242,8 @@ test("verify props is reactive", () => {
             componentWillReceiveProps(nextProps) {
                 events.push(["receive", this.props.item.subid, nextProps.item.subid])
             }
-            componentWillUpdate(nextProps) {
-                events.push(["update", this.props.item.subid, nextProps.item.subid])
+            componentDidUpdate(prevProps) {
+                events.push(["update", prevProps.item.subid, this.props.item.subid])
             }
             render() {
                 events.push([
@@ -329,8 +329,8 @@ test("no re-render for shallow equal props", async () => {
                 events.push(["receive", this.props.item.subid, nextProps.item.subid])
             }
 
-            componentWillUpdate(nextProps) {
-                events.push(["update", this.props.item.subid, nextProps.item.subid])
+            componentDidUpdate(prevProps) {
+                events.push(["update", prevProps.item.subid, this.props.item.subid])
             }
             render() {
                 events.push(["render", this.props.item.subid, this.props.item.label])
@@ -374,12 +374,6 @@ test("lifecycle callbacks called with correct arguments", () => {
     var Comp = observer(
         class Comp extends Component {
             componentWillReceiveProps(nextProps) {
-                // "componentWillReceiveProps: nextProps.counter === 1"
-                expect(nextProps.counter).toBe(1)
-                // "componentWillReceiveProps: this.props.counter === 1"
-                expect(this.props.counter).toBe(0)
-            }
-            componentWillUpdate(nextProps) {
                 // "componentWillReceiveProps: nextProps.counter === 1"
                 expect(nextProps.counter).toBe(1)
                 // "componentWillReceiveProps: this.props.counter === 1"

--- a/test/observer.test.js
+++ b/test/observer.test.js
@@ -341,12 +341,9 @@ test("correctly wraps display name of child component", () => {
 describe("124 - react to changes in this.props via computed", () => {
     const Comp = observer(
         class T extends Component {
-            componentWillMount() {
-                mobx.extendObservable(this, {
-                    get computedProp() {
-                        return this.props.x
-                    }
-                })
+            @mobx.computed
+            get computedProp() {
+                return this.props.x
             }
             render() {
                 return (
@@ -695,39 +692,6 @@ test("parent / childs render in the right order", () => {
     expect(events).toEqual(["parent", "child", "parent"])
 })
 
-test("195 - async componentWillMount does not work", () => {
-    jest.useFakeTimers()
-
-    const renderedValues = []
-
-    @observer
-    class WillMount extends React.Component {
-        @mobx.observable
-        counter = 0
-
-        @mobx.action
-        inc = () => this.counter++
-
-        componentWillMount() {
-            setTimeout(() => this.inc(), 300)
-        }
-
-        render() {
-            renderedValues.push(this.counter)
-            return (
-                <p>
-                    {this.counter}
-                    <button onClick={this.inc}>+</button>
-                </p>
-            )
-        }
-    }
-    render(<WillMount />)
-
-    jest.runAllTimers()
-    expect(renderedValues).toEqual([0, 1])
-})
-
 describe("use Observer inject and render sugar should work  ", () => {
     test("use render without inject should be correct", () => {
         const Comp = () => (
@@ -854,7 +818,8 @@ test("#692 - componentDidUpdate is triggered", () => {
         @mobx.action
         inc = () => this.counter++
 
-        componentWillMount() {
+        constructor() {
+            super()
             setTimeout(() => this.inc(), 300)
         }
 


### PR DESCRIPTION
>React 16.9 does not contain breaking changes, and the old names continue to work in this release. But you will now see a warning when using any of the old names:

https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods

cWM, cWRP, cWU are deprecated, so I don't see any point in testing them.