### PR TITLE
Do not minify bundles

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
     {
-        "path": "dist/mobx-react.js",
+        "path": "dist/mobx-react.umd.js",
         "limit": "4 KB",
         "webpack": false,
         "running": false

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "build": "yarn bundle && yarn copytypes && yarn makern",
     "copytypes": "shx cp src/index.d.ts dist/mobx-react.d.ts",
     "makern": "shx cp dist/mobx-react.module.js dist/mobx-react.rn.module.js && yarn replace \"react-dom\" \"react-native\" dist/mobx-react.rn.module.js --silent",
-    "bundle": "microbundle  --jsx React.createElement --external mobx,react,react-dom,mobx-react-lite --globals react-dom=ReactDOM,react=React,mobx-react-lite=mobxReactLite --name mobxReact",
+    "bundle": "yarn bundle-cjs-and-es && yarn bundle-umd",
+    "bundle-cjs-and-es": "yarn bundle-via-microbundle --format cjs,es --no-compress",
+    "bundle-umd": "yarn bundle-via-microbundle --format umd --globals react-dom=ReactDOM,react=React,mobx-react-lite=mobxReactLite --name mobxReact",
+    "bundle-via-microbundle": "microbundle --jsx React.createElement --external mobx,react,react-dom,mobx-react-lite",
     "watch": "jest --watch"
   },
   "author": "Michel Weststrate",


### PR DESCRIPTION
I think it's a good idea not to minify bundles. I think it's very convenient to be able to edit the module in node_modules directory and it's much easier to do when the script isn't minified. Also source maps can be disabled in dev mode for some reason and not minified bundle can help in this case.
~~I also disabled source maps generation because I don't see the point in it if we don't minify the bundles.~~

Also:
@FredyC 
> I don't think you should be providing a minified code as a main, that should be a job for the consumer
https://github.com/mobxjs/mobx-react/pull/644#issuecomment-475521989