### PR TITLE
Use same naming scheme and styles in imports in tests

### DIFF
--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,11 +1,11 @@
 import React from "react"
-import * as mobx from "mobx"
+import { observable } from "mobx"
 import { Provider, observer, inject } from "../src"
 import TestRenderer from "react-test-renderer"
 import withConsole from "./utils/withConsole"
 
 test("no warnings in modern react", () => {
-    const box = mobx.observable.box(3)
+    const box = observable.box(3)
     const Child = inject("store")(
         observer(
             class Child extends React.Component {

--- a/test/disposeOnUnmount.test.js
+++ b/test/disposeOnUnmount.test.js
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import { disposeOnUnmount, observer } from "../src"
 import { render } from "@testing-library/react"
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react"
+import React from "react"
 import { observer, Observer, useLocalStore, useAsObservableSource } from "../src"
-import renderer, { act } from "react-test-renderer"
+import TestRenderer, { act } from "react-test-renderer"
 
 afterEach(() => {
     jest.useRealTimers()
@@ -23,9 +23,9 @@ test("computed properties react to props when using hooks", async () => {
     }
 
     const Parent = () => {
-        const [state, setState] = useState({ x: 0 })
+        const [state, setState] = React.useState({ x: 0 })
         seen.push("parent")
-        useEffect(() => {
+        React.useEffect(() => {
             setTimeout(() => {
                 act(() => {
                     setState({ x: 2 })
@@ -37,7 +37,7 @@ test("computed properties react to props when using hooks", async () => {
 
     let wrapper
     act(() => {
-        wrapper = renderer.create(<Parent />)
+        wrapper = TestRenderer.create(<Parent />)
     })
     expect(wrapper.toJSON()).toMatchInlineSnapshot(`
 <div>
@@ -72,9 +72,9 @@ test("computed properties result in double render when using observer instead of
     })
 
     const Parent = () => {
-        const [state, setState] = useState({ x: 0 })
+        const [state, setState] = React.useState({ x: 0 })
         seen.push("parent")
-        useEffect(() => {
+        React.useEffect(() => {
             setTimeout(() => {
                 act(() => {
                     setState({ x: 2 })
@@ -86,7 +86,7 @@ test("computed properties result in double render when using observer instead of
 
     let wrapper
     act(() => {
-        wrapper = renderer.create(<Parent />)
+        wrapper = TestRenderer.create(<Parent />)
     })
     expect(wrapper.toJSON()).toMatchInlineSnapshot(`
 <div>

--- a/test/inject.test.js
+++ b/test/inject.test.js
@@ -1,10 +1,9 @@
-import React, { Component } from "react"
-import * as PropTypes from "prop-types"
-import * as mobx from "mobx"
+import React from "react"
+import PropTypes from "prop-types"
 import { action, observable } from "mobx"
 import { observer, inject, Provider } from "../src"
 import { render } from "@testing-library/react"
-import renderer, { act } from "react-test-renderer"
+import TestRenderer, { act } from "react-test-renderer"
 import withConsole from "./utils/withConsole"
 
 describe("inject based context", () => {
@@ -29,7 +28,7 @@ describe("inject based context", () => {
                 <B />
             </Provider>
         )
-        const wrapper = renderer.create(<A />)
+        const wrapper = TestRenderer.create(<A />)
         expect(wrapper).toMatchInlineSnapshot(`
 <div>
   context:
@@ -40,7 +39,7 @@ describe("inject based context", () => {
 
     test("props override context", () => {
         const C = inject("foo")(
-            class T extends Component {
+            class T extends React.Component {
                 render() {
                     return (
                         <div>
@@ -52,7 +51,7 @@ describe("inject based context", () => {
             }
         )
         const B = () => <C foo={42} />
-        const A = class T extends Component {
+        const A = class T extends React.Component {
             render() {
                 return (
                     <Provider foo="bar">
@@ -61,7 +60,7 @@ describe("inject based context", () => {
                 )
             }
         }
-        const wrapper = renderer.create(<A />)
+        const wrapper = TestRenderer.create(<A />)
         expect(wrapper).toMatchInlineSnapshot(`
 <div>
   context:
@@ -72,7 +71,7 @@ describe("inject based context", () => {
 
     test("wraps displayName of original component", () => {
         const A = inject("foo")(
-            class ComponentA extends Component {
+            class ComponentA extends React.Component {
                 render() {
                     return (
                         <div>
@@ -84,7 +83,7 @@ describe("inject based context", () => {
             }
         )
         const B = inject()(
-            class ComponentB extends Component {
+            class ComponentB extends React.Component {
                 render() {
                     return (
                         <div>
@@ -96,7 +95,7 @@ describe("inject based context", () => {
             }
         )
         const C = inject(() => ({}))(
-            class ComponentC extends Component {
+            class ComponentC extends React.Component {
                 render() {
                     return (
                         <div>
@@ -107,19 +106,19 @@ describe("inject based context", () => {
                 }
             }
         )
-        const wrapperA = renderer.create(
+        const wrapperA = TestRenderer.create(
             <Provider foo="foo">
                 <A />
             </Provider>
         )
         expect(wrapperA.root.children[0].type.displayName).toBe("inject-with-foo(ComponentA)")
-        const wrapperB = renderer.create(
+        const wrapperB = TestRenderer.create(
             <Provider foo="foo">
                 <B />
             </Provider>
         )
         expect(wrapperB.root.children[0].type.displayName).toBe("inject(ComponentB)")
-        const wrapperC = renderer.create(
+        const wrapperC = TestRenderer.create(
             <Provider>
                 <C />
             </Provider>
@@ -132,7 +131,7 @@ describe("inject based context", () => {
     test("store should be available", () => {
         const C = inject("foo")(
             observer(
-                class C extends Component {
+                class C extends React.Component {
                     render() {
                         return (
                             <div>
@@ -145,7 +144,7 @@ describe("inject based context", () => {
             )
         )
         const B = () => <C />
-        const A = class A extends Component {
+        const A = class A extends React.Component {
             render() {
                 return (
                     <Provider baz={42}>
@@ -156,7 +155,7 @@ describe("inject based context", () => {
         }
 
         withConsole(() => {
-            expect(() => renderer.create(<A />)).toThrow(
+            expect(() => TestRenderer.create(<A />)).toThrow(
                 /Store 'foo' is not available! Make sure it is provided by some Provider/
             )
         })
@@ -165,7 +164,7 @@ describe("inject based context", () => {
     test("store is not required if prop is available", () => {
         const C = inject("foo")(
             observer(
-                class C extends Component {
+                class C extends React.Component {
                     render() {
                         return (
                             <div>
@@ -178,7 +177,7 @@ describe("inject based context", () => {
             )
         )
         const B = () => <C foo="bar" />
-        const wrapper = renderer.create(<B />)
+        const wrapper = TestRenderer.create(<B />)
         expect(wrapper).toMatchInlineSnapshot(`
 <div>
   context:
@@ -190,7 +189,7 @@ describe("inject based context", () => {
     test("inject merges (and overrides) props", () => {
         const C = inject(() => ({ a: 1 }))(
             observer(
-                class C extends Component {
+                class C extends React.Component {
                     render() {
                         expect(this.props).toEqual({ a: 1, b: 2 })
                         return null
@@ -199,7 +198,7 @@ describe("inject based context", () => {
             )
         )
         const B = () => <C a={2} b={2} />
-        renderer.create(<B />)
+        TestRenderer.create(<B />)
     })
 
     test("custom storesToProps", () => {
@@ -212,7 +211,7 @@ describe("inject based context", () => {
             }
         })(
             observer(
-                class C extends Component {
+                class C extends React.Component {
                     render() {
                         return (
                             <div>
@@ -225,7 +224,7 @@ describe("inject based context", () => {
                 }
             )
         )
-        const B = class B extends Component {
+        const B = class B extends React.Component {
             render() {
                 return <C baz={42} />
             }
@@ -235,7 +234,7 @@ describe("inject based context", () => {
                 <B />
             </Provider>
         )
-        const wrapper = renderer.create(<A />)
+        const wrapper = TestRenderer.create(<A />)
         expect(wrapper).toMatchInlineSnapshot(`
 <div>
   context:
@@ -256,14 +255,14 @@ describe("inject based context", () => {
         }
 
         const ref = React.createRef()
-        renderer.create(<FancyComp ref={ref} />)
+        TestRenderer.create(<FancyComp ref={ref} />)
         expect(typeof ref.current.doSomething).toBe("function")
         expect(ref.current.didRender).toBe(true)
 
         const InjectedFancyComp = inject("bla")(FancyComp)
         const ref2 = React.createRef()
 
-        renderer.create(
+        TestRenderer.create(
             <Provider bla={42}>
                 <InjectedFancyComp ref={ref2} />
             </Provider>
@@ -312,7 +311,7 @@ describe("inject based context", () => {
 
         const ref = React.createRef()
 
-        renderer.create(<C booh={42} ref={ref} />)
+        TestRenderer.create(<C booh={42} ref={ref} />)
         expect(ref.current.testField).toBe(1)
     })
 
@@ -322,7 +321,7 @@ describe("inject based context", () => {
         console.error = m => msg.push(m)
 
         const C = inject(["foo"])(
-            class C extends Component {
+            class C extends React.Component {
                 render() {
                     expect(this.props.y).toEqual(3)
 
@@ -347,7 +346,7 @@ describe("inject based context", () => {
                 <B />
             </Provider>
         )
-        renderer.create(<A />)
+        TestRenderer.create(<A />)
         expect(msg.length).toBe(2)
         expect(msg[0].split("\n")[0]).toBe(
             "Warning: Failed prop type: The prop `x` is marked as required in `inject-with-foo(C)`, but its value is `undefined`."
@@ -364,7 +363,7 @@ describe("inject based context", () => {
         console.warn = m => (msg = m)
 
         const C = inject(["foo"])(
-            class C extends Component {
+            class C extends React.Component {
                 render() {
                     return (
                         <div>
@@ -386,7 +385,7 @@ describe("inject based context", () => {
         const baseWarn = console.warn
         console.warn = m => (msg = m)
         const C = inject(["foo"])(
-            class C extends Component {
+            class C extends React.Component {
                 render() {
                     return (
                         <div>
@@ -403,7 +402,7 @@ describe("inject based context", () => {
     })
 
     test("using a custom injector is reactive", () => {
-        const user = mobx.observable({ name: "Noa" })
+        const user = observable({ name: "Noa" })
         const mapper = stores => ({ name: stores.user.name })
         const DisplayName = props => <h1>{props.name}</h1>
         const User = inject(mapper)(DisplayName)
@@ -412,7 +411,7 @@ describe("inject based context", () => {
                 <User />
             </Provider>
         )
-        const wrapper = renderer.create(<App />)
+        const wrapper = TestRenderer.create(<App />)
 
         expect(wrapper).toMatchInlineSnapshot(`
 <h1>

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -1,13 +1,13 @@
-import React, { Component } from "react"
-import * as mobx from "mobx"
+import React from "react"
+import { extendObservable, isObservable, observable } from "mobx"
 import { observer } from "../src"
-import renderer from "react-test-renderer"
+import TestRenderer from "react-test-renderer"
 import { render } from "@testing-library/react"
 import withConsole from "./utils/withConsole"
 
 test("issue mobx 405", () => {
     function ExampleState() {
-        mobx.extendObservable(this, {
+        extendObservable(this, {
             name: "test",
             get greetings() {
                 return "Hello my name is " + this.name
@@ -16,7 +16,7 @@ test("issue mobx 405", () => {
     }
 
     const ExampleView = observer(
-        class T extends Component {
+        class T extends React.Component {
             render() {
                 return (
                     <div>
@@ -33,7 +33,7 @@ test("issue mobx 405", () => {
     )
 
     const exampleState = new ExampleState()
-    const wrapper = renderer.create(<ExampleView exampleState={exampleState} />)
+    const wrapper = TestRenderer.create(<ExampleView exampleState={exampleState} />)
     expect(wrapper.toJSON()).toMatchInlineSnapshot(`
 <div>
   <input
@@ -49,9 +49,9 @@ test("issue mobx 405", () => {
 })
 
 test("#85 Should handle state changing in constructors", () => {
-    const a = mobx.observable.box(2)
+    const a = observable.box(2)
     const Child = observer(
-        class Child extends Component {
+        class Child extends React.Component {
             constructor(p) {
                 super(p)
                 a.set(3) // one shouldn't do this!
@@ -88,11 +88,11 @@ test("#85 Should handle state changing in constructors", () => {
 
 test("testIsComponentReactive", () => {
     const C = observer(() => null)
-    const wrapper = renderer.create(<C />)
+    const wrapper = TestRenderer.create(<C />)
     const instance = wrapper.getInstance()
 
     // instance is something different then the rendering reaction!
-    expect(mobx.isObservable(instance)).toBeFalsy()
+    expect(isObservable(instance)).toBeFalsy()
 })
 
 test("Do not warn about custom shouldComponentUpdate when it is the one provided by ReactiveMixin", () => {

--- a/test/propTypes.test.js
+++ b/test/propTypes.test.js
@@ -1,5 +1,5 @@
-import * as ReactPropTypes from "prop-types"
-import { PropTypes } from "../src"
+import PropTypes from "prop-types"
+import { PropTypes as MRPropTypes } from "../src"
 import { observable } from "mobx"
 
 // Cause `checkPropTypes` caches errors and doesn't print them twice....
@@ -17,7 +17,7 @@ function typeCheckFail(declaration, value, message) {
     const propTypes = { testProp: declaration }
 
     const compId = "testComponent" + ++testComponentId
-    ReactPropTypes.checkPropTypes(propTypes, props, "prop", compId, null)
+    PropTypes.checkPropTypes(propTypes, props, "prop", compId, null)
 
     error = error.replace(compId, "testComponent")
     expect(error).toBe("Warning: Failed prop type: " + message)
@@ -36,7 +36,7 @@ function typeCheckFailRequiredValues(declaration) {
     const unspecifiedMsg = /but its value is `undefined`\./
 
     const props1 = { testProp: null }
-    ReactPropTypes.checkPropTypes(
+    PropTypes.checkPropTypes(
         propTypes,
         props1,
         "testProp",
@@ -47,7 +47,7 @@ function typeCheckFailRequiredValues(declaration) {
 
     error = ""
     const props2 = { testProp: undefined }
-    ReactPropTypes.checkPropTypes(
+    PropTypes.checkPropTypes(
         propTypes,
         props2,
         "testProp",
@@ -58,7 +58,7 @@ function typeCheckFailRequiredValues(declaration) {
 
     error = ""
     const props3 = {}
-    ReactPropTypes.checkPropTypes(
+    PropTypes.checkPropTypes(
         propTypes,
         props3,
         "testProp",
@@ -72,7 +72,7 @@ function typeCheckFailRequiredValues(declaration) {
 
 function typeCheckPass(declaration, value) {
     const props = { testProp: value }
-    const error = ReactPropTypes.checkPropTypes(
+    const error = PropTypes.checkPropTypes(
         { testProp: declaration },
         props,
         "testProp",
@@ -83,53 +83,53 @@ function typeCheckPass(declaration, value) {
 }
 
 test("Valid values", () => {
-    typeCheckPass(PropTypes.observableArray, observable([]))
-    typeCheckPass(PropTypes.observableArrayOf(ReactPropTypes.string), observable([""]))
-    typeCheckPass(PropTypes.arrayOrObservableArray, observable([]))
-    typeCheckPass(PropTypes.arrayOrObservableArray, [])
-    typeCheckPass(PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string), observable([""]))
-    typeCheckPass(PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string), [""])
-    typeCheckPass(PropTypes.observableObject, observable({}))
-    typeCheckPass(PropTypes.objectOrObservableObject, {})
-    typeCheckPass(PropTypes.objectOrObservableObject, observable({}))
-    typeCheckPass(PropTypes.observableMap, observable(observable.map({}, { deep: false })))
+    typeCheckPass(MRPropTypes.observableArray, observable([]))
+    typeCheckPass(MRPropTypes.observableArrayOf(PropTypes.string), observable([""]))
+    typeCheckPass(MRPropTypes.arrayOrObservableArray, observable([]))
+    typeCheckPass(MRPropTypes.arrayOrObservableArray, [])
+    typeCheckPass(MRPropTypes.arrayOrObservableArrayOf(PropTypes.string), observable([""]))
+    typeCheckPass(MRPropTypes.arrayOrObservableArrayOf(PropTypes.string), [""])
+    typeCheckPass(MRPropTypes.observableObject, observable({}))
+    typeCheckPass(MRPropTypes.objectOrObservableObject, {})
+    typeCheckPass(MRPropTypes.objectOrObservableObject, observable({}))
+    typeCheckPass(MRPropTypes.observableMap, observable(observable.map({}, { deep: false })))
 })
 
 test("should be implicitly optional and not warn", () => {
-    typeCheckPass(PropTypes.observableArray, undefined)
-    typeCheckPass(PropTypes.observableArrayOf(ReactPropTypes.string), undefined)
-    typeCheckPass(PropTypes.arrayOrObservableArray, undefined)
-    typeCheckPass(PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string), undefined)
-    typeCheckPass(PropTypes.observableObject, undefined)
-    typeCheckPass(PropTypes.objectOrObservableObject, undefined)
-    typeCheckPass(PropTypes.observableMap, undefined)
+    typeCheckPass(MRPropTypes.observableArray, undefined)
+    typeCheckPass(MRPropTypes.observableArrayOf(PropTypes.string), undefined)
+    typeCheckPass(MRPropTypes.arrayOrObservableArray, undefined)
+    typeCheckPass(MRPropTypes.arrayOrObservableArrayOf(PropTypes.string), undefined)
+    typeCheckPass(MRPropTypes.observableObject, undefined)
+    typeCheckPass(MRPropTypes.objectOrObservableObject, undefined)
+    typeCheckPass(MRPropTypes.observableMap, undefined)
 })
 
 test("should warn for missing required values, function (test)", () => {
-    typeCheckFailRequiredValues(PropTypes.observableArray.isRequired, undefined)
+    typeCheckFailRequiredValues(MRPropTypes.observableArray.isRequired, undefined)
     typeCheckFailRequiredValues(
-        PropTypes.observableArrayOf(ReactPropTypes.string).isRequired,
+        MRPropTypes.observableArrayOf(PropTypes.string).isRequired,
         undefined
     )
-    typeCheckFailRequiredValues(PropTypes.arrayOrObservableArray.isRequired, undefined)
+    typeCheckFailRequiredValues(MRPropTypes.arrayOrObservableArray.isRequired, undefined)
     typeCheckFailRequiredValues(
-        PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string).isRequired,
+        MRPropTypes.arrayOrObservableArrayOf(PropTypes.string).isRequired,
         undefined
     )
-    typeCheckFailRequiredValues(PropTypes.observableObject.isRequired, undefined)
-    typeCheckFailRequiredValues(PropTypes.objectOrObservableObject.isRequired, undefined)
-    typeCheckFailRequiredValues(PropTypes.observableMap.isRequired, undefined)
+    typeCheckFailRequiredValues(MRPropTypes.observableObject.isRequired, undefined)
+    typeCheckFailRequiredValues(MRPropTypes.objectOrObservableObject.isRequired, undefined)
+    typeCheckFailRequiredValues(MRPropTypes.observableMap.isRequired, undefined)
 })
 
 test("should fail date and regexp correctly", () => {
     typeCheckFail(
-        PropTypes.observableObject,
+        MRPropTypes.observableObject,
         new Date(),
         "Invalid prop `testProp` of type `date` supplied to " +
             "`testComponent`, expected `mobx.ObservableObject`."
     )
     typeCheckFail(
-        PropTypes.observableArray,
+        MRPropTypes.observableArray,
         /please/,
         "Invalid prop `testProp` of type `regexp` supplied to " +
             "`testComponent`, expected `mobx.ObservableArray`."
@@ -138,13 +138,13 @@ test("should fail date and regexp correctly", () => {
 
 test("observableArray", () => {
     typeCheckFail(
-        PropTypes.observableArray,
+        MRPropTypes.observableArray,
         [],
         "Invalid prop `testProp` of type `array` supplied to " +
             "`testComponent`, expected `mobx.ObservableArray`."
     )
     typeCheckFail(
-        PropTypes.observableArray,
+        MRPropTypes.observableArray,
         "",
         "Invalid prop `testProp` of type `string` supplied to " +
             "`testComponent`, expected `mobx.ObservableArray`."
@@ -153,7 +153,7 @@ test("observableArray", () => {
 
 test("arrayOrObservableArray", () => {
     typeCheckFail(
-        PropTypes.arrayOrObservableArray,
+        MRPropTypes.arrayOrObservableArray,
         "",
         "Invalid prop `testProp` of type `string` supplied to " +
             "`testComponent`, expected `mobx.ObservableArray` or javascript `array`."
@@ -162,13 +162,13 @@ test("arrayOrObservableArray", () => {
 
 test("observableObject", () => {
     typeCheckFail(
-        PropTypes.observableObject,
+        MRPropTypes.observableObject,
         {},
         "Invalid prop `testProp` of type `object` supplied to " +
             "`testComponent`, expected `mobx.ObservableObject`."
     )
     typeCheckFail(
-        PropTypes.observableObject,
+        MRPropTypes.observableObject,
         "",
         "Invalid prop `testProp` of type `string` supplied to " +
             "`testComponent`, expected `mobx.ObservableObject`."
@@ -177,7 +177,7 @@ test("observableObject", () => {
 
 test("objectOrObservableObject", () => {
     typeCheckFail(
-        PropTypes.objectOrObservableObject,
+        MRPropTypes.objectOrObservableObject,
         "",
         "Invalid prop `testProp` of type `string` supplied to " +
             "`testComponent`, expected `mobx.ObservableObject` or javascript `object`."
@@ -186,7 +186,7 @@ test("objectOrObservableObject", () => {
 
 test("observableMap", () => {
     typeCheckFail(
-        PropTypes.observableMap,
+        MRPropTypes.observableMap,
         {},
         "Invalid prop `testProp` of type `object` supplied to " +
             "`testComponent`, expected `mobx.ObservableMap`."
@@ -195,19 +195,19 @@ test("observableMap", () => {
 
 test("observableArrayOf", () => {
     typeCheckFail(
-        PropTypes.observableArrayOf(ReactPropTypes.string),
+        MRPropTypes.observableArrayOf(PropTypes.string),
         2,
         "Invalid prop `testProp` of type `number` supplied to " +
             "`testComponent`, expected `mobx.ObservableArray`."
     )
     typeCheckFail(
-        PropTypes.observableArrayOf(ReactPropTypes.string),
+        MRPropTypes.observableArrayOf(PropTypes.string),
         observable([2]),
         "Invalid prop `testProp[0]` of type `number` supplied to " +
             "`testComponent`, expected `string`."
     )
     typeCheckFail(
-        PropTypes.observableArrayOf({ foo: PropTypes.string }),
+        MRPropTypes.observableArrayOf({ foo: MRPropTypes.string }),
         { foo: "bar" },
         "Property `testProp` of component `testComponent` has invalid PropType notation."
     )
@@ -215,25 +215,25 @@ test("observableArrayOf", () => {
 
 test("arrayOrObservableArrayOf", () => {
     typeCheckFail(
-        PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
+        MRPropTypes.arrayOrObservableArrayOf(PropTypes.string),
         2,
         "Invalid prop `testProp` of type `number` supplied to " +
             "`testComponent`, expected `mobx.ObservableArray` or javascript `array`."
     )
     typeCheckFail(
-        PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
+        MRPropTypes.arrayOrObservableArrayOf(PropTypes.string),
         observable([2]),
         "Invalid prop `testProp[0]` of type `number` supplied to " +
             "`testComponent`, expected `string`."
     )
     typeCheckFail(
-        PropTypes.arrayOrObservableArrayOf(ReactPropTypes.string),
+        MRPropTypes.arrayOrObservableArrayOf(PropTypes.string),
         [2],
         "Invalid prop `testProp[0]` of type `number` supplied to " +
             "`testComponent`, expected `string`."
     )
     typeCheckFail(
-        PropTypes.arrayOrObservableArrayOf({ foo: PropTypes.string }),
+        MRPropTypes.arrayOrObservableArrayOf({ foo: MRPropTypes.string }),
         { foo: "bar" },
         "Property `testProp` of component `testComponent` has invalid PropType notation."
     )

--- a/test/stateless.test.js
+++ b/test/stateless.test.js
@@ -1,9 +1,8 @@
-import React, { Component } from "react"
-import * as PropTypes from "prop-types"
-import * as mobx from "mobx"
+import React from "react"
+import PropTypes from "prop-types"
 import { observer, PropTypes as MRPropTypes } from "../src"
 import { render } from "@testing-library/react"
-import renderer, { act } from "react-test-renderer"
+import TestRenderer, { act } from "react-test-renderer"
 import { observable } from "mobx"
 
 const StatelessComp = ({ testProp }) => <div>result: {testProp}</div>
@@ -60,7 +59,7 @@ test("stateless component with context support", () => {
 })
 
 test("component with observable propTypes", () => {
-    class Comp extends Component {
+    class Comp extends React.Component {
         render() {
             return null
         }
@@ -76,7 +75,7 @@ test("component with observable propTypes", () => {
     const firstWrapper = <Comp a1={[]} a2={[]} />
     expect(warnings.length).toBe(1)
     // eslint-disable-next-line no-unused-vars
-    const secondWrapper = <Comp a1={mobx.observable([])} a2={mobx.observable([])} />
+    const secondWrapper = <Comp a1={observable([])} a2={observable([])} />
     expect(warnings.length).toBe(1)
     console.error = originalConsoleError
 })
@@ -96,14 +95,14 @@ describe("stateless component with forwardRef", () => {
     )
 
     test("render test correct", () => {
-        const component = renderer.create(
+        const component = TestRenderer.create(
             <ForwardRefCompObserver testProp="hello world" ref={React.createRef()} />
         )
         expect(component).toMatchSnapshot()
     })
 
     test("is reactive", () => {
-        const component = renderer.create(
+        const component = TestRenderer.create(
             <ForwardRefCompObserver testProp="hello world" ref={React.createRef()} />
         )
         act(() => {

--- a/test/symbol.test.js
+++ b/test/symbol.test.js
@@ -1,14 +1,14 @@
 // eslint-disable-next-line no-undef
 delete global.Symbol
 
-import React, { Component } from "react"
+import React from "react"
 import { observer } from "../src"
 import { render } from "@testing-library/react"
 import { newSymbol } from "../src/utils/utils"
 
 test("work without Symbol", () => {
     const Component1 = observer(
-        class extends Component {
+        class extends React.Component {
             render() {
                 return null
             }

--- a/test/transactions.test.js
+++ b/test/transactions.test.js
@@ -1,27 +1,27 @@
-import React, { Component } from "react"
-import * as mobx from "mobx"
-import * as mobxReact from "../src"
+import React from "react"
+import { autorun, computed, observable, transaction } from "mobx"
+import { observer } from "../src"
 import { render } from "@testing-library/react"
 
 test("mobx issue 50", async () => {
     const foo = {
-        a: mobx.observable.box(true),
-        b: mobx.observable.box(false),
-        c: mobx.computed(function() {
+        a: observable.box(true),
+        b: observable.box(false),
+        c: computed(function() {
             // console.log("evaluate c")
             return foo.b.get()
         })
     }
     function flipStuff() {
-        mobx.transaction(() => {
+        transaction(() => {
             foo.a.set(!foo.a.get())
             foo.b.set(!foo.b.get())
         })
     }
     let asText = ""
-    mobx.autorun(() => (asText = [foo.a.get(), foo.b.get(), foo.c.get()].join(":")))
-    const Test = mobxReact.observer(
-        class Test extends Component {
+    autorun(() => (asText = [foo.a.get(), foo.b.get(), foo.c.get()].join(":")))
+    const Test = observer(
+        class Test extends React.Component {
             render() {
                 return <div id="x">{[foo.a.get(), foo.b.get(), foo.c.get()].join(",")}</div>
             }
@@ -38,11 +38,11 @@ test("mobx issue 50", async () => {
 })
 
 test("ReactDOM.render should respect transaction", () => {
-    const a = mobx.observable.box(2)
-    const loaded = mobx.observable.box(false)
+    const a = observable.box(2)
+    const loaded = observable.box(false)
     const valuesSeen = []
 
-    const Component = mobxReact.observer(() => {
+    const Component = observer(() => {
         valuesSeen.push(a.get())
         if (loaded.get()) return <div>{a.get()}</div>
         else return <div>loading</div>
@@ -50,7 +50,7 @@ test("ReactDOM.render should respect transaction", () => {
 
     const { container } = render(<Component />)
 
-    mobx.transaction(() => {
+    transaction(() => {
         a.set(3)
         a.set(4)
         loaded.set(true)
@@ -61,10 +61,10 @@ test("ReactDOM.render should respect transaction", () => {
 })
 
 test("ReactDOM.render in transaction should succeed", () => {
-    const a = mobx.observable.box(2)
-    const loaded = mobx.observable.box(false)
+    const a = observable.box(2)
+    const loaded = observable.box(false)
     const valuesSeen = []
-    const Component = mobxReact.observer(() => {
+    const Component = observer(() => {
         valuesSeen.push(a.get())
         if (loaded.get()) return <div>{a.get()}</div>
         else return <div>loading</div>
@@ -72,7 +72,7 @@ test("ReactDOM.render in transaction should succeed", () => {
 
     let container
 
-    mobx.transaction(() => {
+    transaction(() => {
         a.set(3)
         container = render(<Component />).container
         a.set(4)

--- a/test/ts/compile-ts.tsx
+++ b/test/ts/compile-ts.tsx
@@ -1,26 +1,25 @@
-import * as React from "react"
-import * as ReactDOM from "react-dom"
-import { Component } from "react"
-import * as ClassicPropTypes from "prop-types"
+import React from "react"
+import ReactDOM from "react-dom"
+import PropTypes from "prop-types"
 import {
     observer,
     Provider,
     inject,
     Observer,
     disposeOnUnmount,
-    PropTypes,
+    PropTypes as MRPropTypes,
     useLocalStore
 } from "../../src"
 
 @observer
-class T1 extends Component<{ pizza: number }, {}> {
+class T1 extends React.Component<{ pizza: number }, {}> {
     render() {
         return <div>{this.props.pizza}</div>
     }
 }
 
 const T2 = observer(
-    class T2 extends Component<{ cake: number; zoem: any[] }> {
+    class T2 extends React.Component<{ cake: number; zoem: any[] }> {
         defaultProps = { cake: 7 }
         render() {
             return (
@@ -30,7 +29,7 @@ const T2 = observer(
             )
         }
         static propTypes = {
-            zoem: PropTypes.arrayOrObservableArray
+            zoem: MRPropTypes.arrayOrObservableArray
         }
     }
 )
@@ -50,7 +49,7 @@ const T5 = observer(() => {
 })
 
 @observer
-class T6 extends Component<{}, {}> {
+class T6 extends React.Component<{}, {}> {
     render() {
         return (
             <span>
@@ -65,7 +64,7 @@ class T6 extends Component<{}, {}> {
 
 const x = React.createElement(T3, { hamburger: 4 })
 
-class T7 extends Component<{ pizza: number }, {}> {
+class T7 extends React.Component<{ pizza: number }, {}> {
     render() {
         return <div>{this.props.pizza}</div>
     }
@@ -74,7 +73,7 @@ React.createElement(observer(T7), { pizza: 4 })
 
 ReactDOM.render(<T5 />, document.body)
 
-class ProviderTest extends Component<any, any> {
+class ProviderTest extends React.Component<any, any> {
     render() {
         return (
             <Provider foo={32}>
@@ -85,7 +84,7 @@ class ProviderTest extends Component<any, any> {
 }
 
 @inject(() => ({ x: 3 }))
-class T11 extends Component<{ pizza: number; x?: number }, {}> {
+class T11 extends React.Component<{ pizza: number; x?: number }, {}> {
     render() {
         return (
             <div>
@@ -96,7 +95,7 @@ class T11 extends Component<{ pizza: number; x?: number }, {}> {
     }
 }
 
-class T15 extends Component<{ pizza: number; x?: number }, {}> {
+class T15 extends React.Component<{ pizza: number; x?: number }, {}> {
     render() {
         return (
             <div>
@@ -108,7 +107,7 @@ class T15 extends Component<{ pizza: number; x?: number }, {}> {
 }
 const T16 = inject(() => ({ x: 3 }))(T15)
 
-class T17 extends Component<{}, {}> {
+class T17 extends React.Component<{}, {}> {
     render() {
         return (
             <div>
@@ -124,7 +123,7 @@ class T17 extends Component<{}, {}> {
 }
 
 @inject("a", "b")
-class T12 extends Component<{ pizza: number }, {}> {
+class T12 extends React.Component<{ pizza: number }, {}> {
     render() {
         return <div>{this.props.pizza}</div>
     }
@@ -132,7 +131,7 @@ class T12 extends Component<{ pizza: number }, {}> {
 
 @inject("a", "b")
 @observer
-class T13 extends Component<{ pizza: number }, {}> {
+class T13 extends React.Component<{ pizza: number }, {}> {
     render() {
         return <div>{this.props.pizza}</div>
     }
@@ -143,7 +142,7 @@ const LoginContainer = inject((allStores, props) => ({
     z: 7
 }))(
     observer(
-        class _LoginContainer extends Component<
+        class _LoginContainer extends React.Component<
             {
                 x: string
                 store?: { y: boolean; z: number }
@@ -151,7 +150,7 @@ const LoginContainer = inject((allStores, props) => ({
             {}
         > {
             static contextTypes: React.ValidationMap<any> = {
-                router: ClassicPropTypes.func.isRequired
+                router: PropTypes.func.isRequired
             }
 
             render() {
@@ -172,7 +171,7 @@ ReactDOM.render(<LoginContainer x="test" />, document.body)
     store: { y: true, z: 2 }
 }))
 @observer
-class LoginContainer2 extends Component<
+class LoginContainer2 extends React.Component<
     {
         x: string
         store?: { y: boolean }
@@ -180,7 +179,7 @@ class LoginContainer2 extends Component<
     {}
 > {
     static contextTypes: React.ValidationMap<any> = {
-        router: ClassicPropTypes.func.isRequired
+        router: PropTypes.func.isRequired
     }
 
     render() {
@@ -196,20 +195,20 @@ class LoginContainer2 extends Component<
 
 ReactDOM.render(<LoginContainer2 x="test" />, document.body)
 
-class ObserverTest extends Component<any, any> {
+class ObserverTest extends React.Component<any, any> {
     render() {
         return <Observer>{() => <div>test</div>}</Observer>
     }
 }
 
-class ObserverTest2 extends Component<any, any> {
+class ObserverTest2 extends React.Component<any, any> {
     render() {
         return <Observer render={() => <div>test</div>} />
     }
 }
 
 @observer
-class ComponentWithoutPropsAndState extends Component<{}, {}> {
+class ComponentWithoutPropsAndState extends React.Component<{}, {}> {
     componentDidUpdate() {}
 
     render() {
@@ -232,9 +231,9 @@ App.wrappedComponent
 
 @inject("store")
 @observer
-class App2 extends Component<{ a: number }, {}> {}
+class App2 extends React.Component<{ a: number }, {}> {}
 
-class InjectSomeStores extends Component<{ x: any }, {}> {
+class InjectSomeStores extends React.Component<{ x: any }, {}> {
     render() {
         return <div>Hello World</div>
     }
@@ -243,7 +242,7 @@ class InjectSomeStores extends Component<{ x: any }, {}> {
 inject(({ x }) => ({ x }))(InjectSomeStores)
 
 {
-    class T extends Component<{ x: number }> {
+    class T extends React.Component<{ x: number }> {
         render() {
             return <div />
         }
@@ -255,7 +254,7 @@ inject(({ x }) => ({ x }))(InjectSomeStores)
 
 {
     // just to make sure it compiles
-    class DisposeOnUnmountComponent extends Component<{}> {
+    class DisposeOnUnmountComponent extends React.Component<{}> {
         @disposeOnUnmount
         methodA = () => {}
 

--- a/test/ts/tsconfig.json
+++ b/test/ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"version": "1.7.5",
 	"compilerOptions": {
+		"esModuleInterop": true,
 		"target": "es5",
 		"strict": true,
 		"experimentalDecorators": true,


### PR DESCRIPTION
When working with the tests, I constantly encountered different naming and import styles in the tests. I think it's best to use the same naming style for imports. This reduces the cognitive load when working with the existing code and allows you not to think about what style to use when writing a new code.

I also want to use the same style in modules located in the `src directory`. If you don't mind, I'll do it in a separate PR.