### PR TITLE
Update mobx-react-lite dependency to support all enforceAction modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^2.6.0"
   },
   "dependencies": {
-    "mobx-react-lite": "1.4.0"
+    "mobx-react-lite": "1.4.1"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6302,10 +6302,10 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mobx-react-lite@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.4.0.tgz#193beb5fdddf17ae61542f65ff951d84db402351"
-  integrity sha512-5xCuus+QITQpzKOjAOIQ/YxNhOl/En+PlNJF+5QU4Qxn9gnNMJBbweAdEW3HnuVQbfqDYEUnkGs5hmkIIStehg==
+mobx-react-lite@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.4.1.tgz#7307a45901f97f9a07ebed32b654235507644e1a"
+  integrity sha512-XmM+gzNv+GyXZYDLZMIGox3DufIiKULYgJsLhQj0U6Wlf+J5jv/h7limrL0aS1bEUtNilG62g9nwTeQ0KHzLFg==
 
 mobx@^5.0.0:
   version "5.9.0"


### PR DESCRIPTION
A request was made in [mobx-react-lite](https://github.com/mobxjs/mobx-react-lite/issues/170#issuecomment-525396740) to update mobx-react's dependency on mobx-react-lite to the version with support for mobx' `enforceActions` configuration support.

I believe this just this version bump is all that is needed. @FredyC is there anything else that went into 1.4.1 that could affect mobx-react? I couldn't find any release notes on 1.4.1.