### PR TITLE
fix PureComponent class check for length > 1 prototype chains

### DIFF
--- a/src/observerClass.js
+++ b/src/observerClass.js
@@ -13,7 +13,7 @@ export function makeClassComponentObserver(componentClass) {
     const target = componentClass.prototype
     if (target.componentWillReact)
         throw new Error("The componentWillReact life-cycle event is no longer supported")
-    if (componentClass.__proto__ !== PureComponent) {
+    if (!(target instanceof PureComponent)) {
         if (!target.shouldComponentUpdate) target.shouldComponentUpdate = observerSCU
         else if (target.shouldComponentUpdate !== observerSCU)
             // n.b. unequal check, instead of existence check, as @observer might be on superclass as well


### PR DESCRIPTION
The __proto__ check fails if a component doesn't directly extend from `PureComponent`. Example:

```js
@observer
class ItemCell extends PureComponent {
}

@observer
class MessageCell extends ItemCell {

}
```

Results in:
```
Warning: MessageCell has a method called shouldComponentUpdate(). shouldComponentUpdate should not be used when extending React.PureComponent. Please extend React.Component if shouldComponentUpdate is used.
```

Changing the inherits from PureComponent check to be `componentClass.prototype instanceof PureComponent` takes care of the problem.