### PR TITLE
Opt-in variant of batched updates

### DIFF
--- a/batchingForReactDom.js
+++ b/batchingForReactDom.js
@@ -1,0 +1,1 @@
+require("mobx-react-lite/batchingForReactDom")

--- a/batchingForReactNative.js
+++ b/batchingForReactNative.js
@@ -1,0 +1,1 @@
+require("mobx-react-lite/batchingForReactNative")

--- a/batchingOptOut.js
+++ b/batchingOptOut.js
@@ -1,0 +1,1 @@
+require("mobx-react-lite/batchingOptOut")

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "typescript": "^3.7.0"
   },
   "dependencies": {
-    "mobx-react-lite": "^1.4.2"
+    "mobx-react-lite": "2"
   },
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,15 @@ if (!observable) throw new Error("mobx-react requires mobx to be available")
 if (typeof rdBatched === "function") configure({ reactionScheduler: rdBatched })
 
 export {
-    isUsingStaticRendering,
     Observer,
     useObserver,
     useAsObservableSource,
     useLocalStore,
-    useStaticRendering
+    isUsingStaticRendering,
+    useStaticRendering,
+    observerBatching,
+    observerBatchingOptOut,
+    isObserverBatched
 } from "mobx-react-lite"
 
 export { observer } from "./observer"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7189,10 +7189,10 @@ mkdirp@0.5.1, mkdirp@0.x, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mobx-react-lite@^1.4.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz#c4395b0568b9cb16f07669d8869cc4efa1b8656d"
-  integrity sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==
+mobx-react-lite@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-2.0.0.tgz#52ee837a81b4a4cd02fe4a2e6e9433da89b6f9a5"
+  integrity sha512-IrA0WR8f15hq1BLnNfgtQQ0Gp9zRASLZxXEVfiJv8uTwj1K/wN7vHAJtr9YJyBFia0W6QUAXFPP0PHdV0M/L9g==
 
 mobx@^5.15.4:
   version "5.15.4"


### PR DESCRIPTION
Mostly just reexport of the https://github.com/mobxjs/mobx-react-lite/pull/214.

In some distant future when 7.0 comes out, we can remove react-native specific bundle. Although it would be nice to somehow deprecate it now. Ideas?