### PR TITLE
Fix for component-class not disposing reaction if render() is hot-swapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MobX-React Changelog
 
+### 6.1.5
+
+-   Fixed that component-class would not dispose reaction if render() was hot-swapped. Fixes: [#797](https://github.com/mobxjs/mobx-react/issues/797)
+
+Resolves #797.
+
 ### 6.1.4
 
 -   Update dependency mobx-react-lite@1.4.2 which includes fix for [RN Fast Refresh](https://github.com/mobxjs/mobx-react-lite/issues/226)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 -   Fixed that component-class would not dispose reaction if render() was hot-swapped. Fixes: [#797](https://github.com/mobxjs/mobx-react/issues/797)
 
-Resolves #797.
-
 ### 6.1.4
 
 -   Update dependency mobx-react-lite@1.4.2 which includes fix for [RN Fast Refresh](https://github.com/mobxjs/mobx-react-lite/issues/226)

--- a/src/observerClass.js
+++ b/src/observerClass.js
@@ -1,10 +1,11 @@
 import { PureComponent, Component } from "react"
-import { createAtom, _allowStateChanges, Reaction, $mobx } from "mobx"
+import { createAtom, _allowStateChanges, Reaction } from "mobx"
 import { isUsingStaticRendering } from "mobx-react-lite"
 
 import { newSymbol, shallowEqual, setHiddenProp, patch } from "./utils/utils"
 
-const mobxAdminProperty = $mobx || "$mobx"
+export const mobxAdminPropertyForRender =
+    typeof Symbol !== "undefined" ? Symbol("mobx administration - render") : "$mobx_render"
 const mobxIsUnmounted = newSymbol("isUnmounted")
 const skipRenderKey = newSymbol("skipRender")
 const isForcingUpdateKey = newSymbol("isForcingUpdate")
@@ -35,7 +36,7 @@ export function makeClassComponentObserver(componentClass) {
     }
     patch(target, "componentWillUnmount", function() {
         if (isUsingStaticRendering() === true) return
-        this.render[mobxAdminProperty] && this.render[mobxAdminProperty].dispose()
+        this[mobxAdminPropertyForRender] && this[mobxAdminPropertyForRender].dispose()
         this[mobxIsUnmounted] = true
     })
     return componentClass
@@ -85,7 +86,7 @@ function makeComponentReactive(render) {
         }
     })
     reaction.reactComponent = this
-    reactiveRender[mobxAdminProperty] = reaction
+    this[mobxAdminPropertyForRender] = reaction
     this.render = reactiveRender
 
     function reactiveRender() {

--- a/src/observerClass.js
+++ b/src/observerClass.js
@@ -4,8 +4,7 @@ import { isUsingStaticRendering } from "mobx-react-lite"
 
 import { newSymbol, shallowEqual, setHiddenProp, patch } from "./utils/utils"
 
-export const mobxAdminPropertyForRender =
-    typeof Symbol !== "undefined" ? Symbol("mobx administration - render") : "$mobx_render"
+export const mobxAdminKeyForRender = newSymbol("mobx administration for render")
 const mobxIsUnmounted = newSymbol("isUnmounted")
 const skipRenderKey = newSymbol("skipRender")
 const isForcingUpdateKey = newSymbol("isForcingUpdate")
@@ -36,7 +35,7 @@ export function makeClassComponentObserver(componentClass) {
     }
     patch(target, "componentWillUnmount", function() {
         if (isUsingStaticRendering() === true) return
-        this[mobxAdminPropertyForRender] && this[mobxAdminPropertyForRender].dispose()
+        this[mobxAdminKeyForRender] && this[mobxAdminKeyForRender].dispose()
         this[mobxIsUnmounted] = true
     })
     return componentClass
@@ -86,7 +85,7 @@ function makeComponentReactive(render) {
         }
     })
     reaction.reactComponent = this
-    this[mobxAdminPropertyForRender] = reaction
+    this[mobxAdminKeyForRender] = reaction
     this.render = reactiveRender
 
     function reactiveRender() {

--- a/test/observer.test.js
+++ b/test/observer.test.js
@@ -10,7 +10,7 @@ import {
     transaction
 } from "mobx"
 import withConsole from "./utils/withConsole"
-import { mobxAdminPropertyForRender } from "../src/observerClass"
+import { mobxAdminKeyForRender } from "../src/observerClass"
 
 /**
  *  some test suite is too tedious
@@ -856,7 +856,7 @@ test("#797 - replacing this.render should not break disposing of reaction", () =
     const compRef = React.createRef()
     const { unmount } = render(<Component ref={compRef} />)
 
-    const reaction = compRef.current[mobxAdminPropertyForRender]
+    const reaction = compRef.current[mobxAdminKeyForRender]
     expect(reaction.isDisposed).toEqual(false)
 
     compRef.current.swapRenderFunc()


### PR DESCRIPTION
* Fixed issue 797 (reaction never being disposed if this.render gets hot-swapped) by having the reaction be stored on the component instance itself, rather than its render function. (since its render function may be swapped out, eg. wrapping the render-func to add logging) Resolves #797.
* Added test for the above issue, to prevent regressions.