### PR TITLE
Warn if attempting to modify comp.render after MobX has attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MobX-React Changelog
 
+### 6.1.5
+
+-   Added warning for attempting to modify a component class' render function after a MobX reaction has already attached. Helps prevent memory leaks as in: [#797](https://github.com/mobxjs/mobx-react/issues/797)
+
 ### 6.1.4
 
 -   Update dependency mobx-react-lite@1.4.2 which includes fix for [RN Fast Refresh](https://github.com/mobxjs/mobx-react-lite/issues/226)

--- a/src/observerClass.js
+++ b/src/observerClass.js
@@ -37,7 +37,7 @@ export function makeClassComponentObserver(componentClass) {
         if (isUsingStaticRendering() === true) return
         if (this.render[mobxAdminProperty]) {
             this.render[mobxAdminProperty].dispose()
-        } else {
+        } else if (process.env.NODE_ENV !== "production") {
             const displayName = getDisplayName(this)
             console.warn(
                 `The render function for an observer component (${displayName}) was modified after MobX attached. This is not supported, since the new function can't be triggered by MobX.`


### PR DESCRIPTION
* Added warning for attempting to modify a component class' render function after a MobX reaction has already attached. Helps prevent memory leaks as in #797. (So mostly resolves [#797](https://github.com/mobxjs/mobx-react/issues/797))
* Added test for the above.
* Added changelog entry.