### PR TITLE
Issue #801: Check if process.env is defined when using Provider

### DIFF
--- a/src/Provider.js
+++ b/src/Provider.js
@@ -11,7 +11,7 @@ export function Provider({ children, ...stores }) {
         ...stores
     }).current
 
-    if (process.env.NODE_ENV !== "production") {
+    if (process && typeof process.env !== "undefined" && process.env.NODE_ENV !== "production") {
         const newValue = { ...value, ...stores } // spread in previous state for the context based stores
         if (!shallowEqual(value, newValue)) {
             throw new Error(


### PR DESCRIPTION
Resolves issue #801, where `process.env` may not exist when using a `Provider` which can cause an application to crash. Simple check to ensure that the browser does not throw a reference error. This is only used in `Provider.js` to throw an error in development builds if we detect that the set of stores have changed.