### PR TITLE
Transform template literals to fix IE11 compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-    "presets": [["@babel/preset-env", { "targets": { "node": "current" } }]],
-    "plugins": [
-        ["@babel/plugin-proposal-decorators", { "legacy": true}],
-        ["@babel/plugin-proposal-class-properties", { "loose": true}],
-        "@babel/plugin-transform-react-jsx"
-    ]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
         "sourceMap": false,
         "strict": true,
         "suppressImplicitAnyIndexErrors": true,
-        "target": "es6"
+        "target": "es5"
     },
     "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
Hi, thanks for publishing this lib!

It appears that since the build tools overhaul in #821 all of the js bundles in `dist`/npm now include template literals (backticks ` `` ` with interpolation), an ES6 feature which effectively [breaks support for Internet Explorer 11 (and older)](https://caniuse.com/#search=template%20literals).

`dist/mobx-react.module.js:14` in v6.1.5:
```js
  var symbol = "__$mobx-react " + name + " (" + symbolId + ")";
```

`dist/mobxreact.cjs.development.js:20` in v6.1.7
```ts
  const symbol = `__$mobx-react ${name} (${symbolId})`;
```

The [symbol generation util](https://github.com/mobxjs/mobx-react/blob/bba25e367fe90953d12a4805f120fc58ea7fd505/src/utils/utils.ts#L6) appears to be the source, but it seems to be only have propagated this way to NPM in v6.1.6 onwards.

Adding [`@babel/plugin-transform-template-literals`](https://babeljs.io/docs/en/babel-plugin-transform-template-literals) to `.babelrc` appears to do the trick but I'm not entirely across the build tooling or other package distribution issues.

`dist/mobxreact.cjs.development.js:20` with this change:
```ts
  const symbol = "__$mobx-react ".concat(name, " (").concat(symbolId, ")");
```

Is this the right path forward? Cheers!