### PR TITLE
fix disposeOnUnmount when using react-hot-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 6.2.3
 
 -   Log warning if class component is already an observer to prevent memory leaks.  [#839](https://github.com/mobxjs/mobx-react/issues/839)
+-   Fix disposeOnUnmount when using react-hot-loader.  [#725](https://github.com/mobxjs/mobx-react/issues/725)
 
 ### 6.2.2
 

--- a/src/disposeOnUnmount.ts
+++ b/src/disposeOnUnmount.ts
@@ -31,14 +31,18 @@ export function disposeOnUnmount(
         return propertyKeyOrFunction.map(fn => disposeOnUnmount(target, fn))
     }
 
-    const c = Object.getPrototypeOf(target).constructor || Object.getPrototypeOf(target.constructor)
+    const c = Object.getPrototypeOf(target).constructor
     const c2 = Object.getPrototypeOf(target.constructor)
+    // Special case for react-hot-loader
+    const c3 = Object.getPrototypeOf(Object.getPrototypeOf(target))
     if (
         !(
             c === React.Component ||
             c === React.PureComponent ||
             c2 === React.Component ||
-            c2 === React.PureComponent
+            c2 === React.PureComponent ||
+            c3 === React.Component ||
+            c3 === React.PureComponent
         )
     ) {
         throw new Error(


### PR DESCRIPTION
### Code change checklist

-   [ ] Added/updated unit tests
-   [x] Updated changelog
-   [x] Updated `README` if applicable

Fixes https://github.com/mobxjs/mobx-react/issues/725
Closed because "Solution is using react-fast-refresh". react-fast-refresh is mostly not production ready. This fix ensures compatibility.
I did not manage to recreate react-hot-loader's behavior as unit test.