### PR TITLE
Fix link to official documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import { observer } from "mobx-react"
 ```
 
 This package provides the bindings for MobX and React.
-See the [official documentation](https://mobx.js.org/react/react-integration.html) for how to get started.
+See the [official documentation](https://mobx.js.org/react-integration.html) for how to get started.
 
 For greenfield projects you might want to consider to use [mobx-react-lite](https://github.com/mobxjs/mobx-react-lite), if you intend to only use function based components. `React.createContext` can be used to pass stores around.
 


### PR DESCRIPTION
The current link follows to this page:

![image](https://user-images.githubusercontent.com/8848858/95896121-74278500-0d94-11eb-81ec-05ad222f80b9.png)
